### PR TITLE
Create Eciggy UK static site

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# OS generated files
+.DS_Store
+Thumbs.db
+Icon?
+
+# Editor settings
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment
+.env
+.env.*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Eciggy UK Static Brochure
+
+Fruity-themed static site for Eciggy UK, suitable for GitHub Pages hosting. Includes hero content, product showcase, and a dedicated contact page with FormSubmit integration.
+
+## Deploy to GitHub Pages
+1. Push the contents of this repository to the `main` branch on GitHub.
+2. In GitHub, open **Settings → Pages**.
+3. Under **Build and deployment**, choose **Branch: `main`** and **Folder: `/ (root)`**.
+4. Save. Pages will publish shortly at `https://<your-username>.github.io/<repository>/`.
+
+## Customise content
+- **Colours**: Update the CSS custom properties at the top of [`assets/css/style.css`](assets/css/style.css) to adjust background and accent colours.
+- **Telephone link**: Replace the `tel:` value in [`index.html`](index.html) and [`pages/contact.html`](pages/contact.html) with your store's phone number.
+- **FormSubmit action**: Swap `https://formsubmit.co/your-form-id` in [`pages/contact.html`](pages/contact.html) with the FormSubmit endpoint generated for your email address.
+
+## Accessibility
+- Semantic HTML structure with skip link and focus outlines.
+- Prefers-reduced-motion respected for users who disable animations.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,489 @@
+:root {
+  color-scheme: dark light;
+  --colour-base: #0b0c10;
+  --colour-surface: #161821;
+  --colour-surface-alt: #1f2130;
+  --colour-text: #f2f4ff;
+  --colour-muted: rgba(242, 244, 255, 0.72);
+  --colour-border: rgba(242, 244, 255, 0.16);
+  --accent-lemon: #ffd447;
+  --accent-strawberry: #ff6f91;
+  --accent-blueberry: #6d8bff;
+  --accent-grape: #b96bff;
+  --font-body: "Poppins", "Segoe UI", sans-serif;
+  --max-width: 72rem;
+  --transition-speed: 0.3s;
+  --shadow-soft: 0 1.25rem 2.5rem rgba(0, 0, 0, 0.16);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  background: radial-gradient(circle at top left, rgba(255, 214, 71, 0.15), transparent 35%),
+    radial-gradient(circle at top right, rgba(255, 111, 145, 0.15), transparent 40%),
+    radial-gradient(circle at bottom left, rgba(109, 139, 255, 0.12), transparent 45%),
+    var(--colour-base);
+  color: var(--colour-text);
+  line-height: 1.6;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+a {
+  color: inherit;
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--accent-strawberry);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.skip-link {
+  position: absolute;
+  top: 0.75rem;
+  left: 50%;
+  transform: translate(-50%, -140%);
+  background: var(--colour-text);
+  color: var(--colour-base);
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  z-index: 1000;
+  transition: transform var(--transition-speed) ease;
+}
+
+.skip-link:focus {
+  transform: translate(-50%, 0);
+}
+
+.container {
+  width: min(100% - 2.5rem, var(--max-width));
+  margin-inline: auto;
+}
+
+.site-header {
+  background: rgba(15, 16, 24, 0.85);
+  backdrop-filter: blur(12px);
+  position: sticky;
+  top: 0;
+  z-index: 999;
+  border-bottom: 1px solid var(--colour-border);
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 1.125rem;
+}
+
+.brand__mark {
+  display: grid;
+  place-items: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent-grape), var(--accent-strawberry));
+  font-size: 1.4rem;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  transition: max-height var(--transition-speed) ease;
+}
+
+.nav__list {
+  display: flex;
+  gap: 1.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav__list a {
+  text-decoration: none;
+  font-weight: 500;
+  position: relative;
+  padding-block: 0.25rem;
+}
+
+.nav__list a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.3rem;
+  width: 100%;
+  height: 2px;
+  transform: scaleX(0);
+  transform-origin: right;
+  background: currentColor;
+  transition: transform var(--transition-speed) ease;
+}
+
+.nav__list a:hover::after,
+.nav__list a:focus-visible::after,
+.nav__list a[aria-current="page"]::after {
+  transform: scaleX(1);
+  transform-origin: left;
+}
+
+.nav-toggle {
+  appearance: none;
+  border: 1px solid var(--colour-border);
+  background: var(--colour-surface);
+  color: var(--colour-text);
+  border-radius: 0.75rem;
+  padding: 0.5rem;
+  display: none;
+  flex-direction: column;
+  gap: 0.35rem;
+  cursor: pointer;
+}
+
+.nav-toggle__bar {
+  width: 1.5rem;
+  height: 2px;
+  background: currentColor;
+  border-radius: 999px;
+}
+
+.hero {
+  padding: 6rem 0 4.5rem;
+  position: relative;
+}
+
+.hero__layout {
+  display: grid;
+  gap: 3rem;
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+}
+
+.hero__copy h1 {
+  font-size: clamp(2.25rem, 3vw + 1rem, 3.5rem);
+  line-height: 1.15;
+  margin-bottom: 1rem;
+}
+
+.hero__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 2rem;
+}
+
+.hero__visual {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(6rem, 1fr));
+  gap: 1.5rem;
+  justify-items: center;
+}
+
+.hero__fruit {
+  width: 7rem;
+  aspect-ratio: 1 / 1;
+  border-radius: 30% 70% 70% 30% / 40% 30% 70% 60%;
+  filter: drop-shadow(var(--shadow-soft));
+  opacity: 0.85;
+}
+
+.hero__fruit--lemon {
+  background: linear-gradient(135deg, var(--accent-lemon), #ffb347);
+}
+
+.hero__fruit--berry {
+  background: linear-gradient(135deg, var(--accent-strawberry), #ff3f74);
+}
+
+.hero__fruit--grape {
+  background: linear-gradient(135deg, var(--accent-grape), #7a3bff);
+}
+
+.section {
+  padding: 4rem 0;
+}
+
+.section--highlight {
+  background: rgba(21, 22, 31, 0.85);
+}
+
+.section__lead {
+  color: var(--colour-muted);
+  max-width: 40ch;
+}
+
+.product-grid {
+  margin-top: 2.5rem;
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.product-card {
+  background: var(--colour-surface);
+  border-radius: 1.25rem;
+  overflow: hidden;
+  border: 1px solid var(--colour-border);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  transition: transform var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
+}
+
+.product-card:hover,
+.product-card:focus-within {
+  transform: translateY(-0.4rem);
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.26);
+}
+
+.product-card__body {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.product-card__tag {
+  justify-self: start;
+}
+
+.btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  background: linear-gradient(135deg, var(--accent-strawberry), var(--accent-blueberry));
+  color: #0b0c10;
+  overflow: hidden;
+  transition: transform var(--transition-speed) ease;
+}
+
+.btn:hover,
+.btn:focus-visible {
+  transform: translateY(-2px);
+}
+
+.btn--outline {
+  background: transparent;
+  color: var(--colour-text);
+  border: 2px solid var(--accent-blueberry);
+}
+
+.btn--outline:hover,
+.btn--outline:focus-visible {
+  color: var(--colour-base);
+  background: var(--accent-blueberry);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--colour-base);
+}
+
+.chip--lemon {
+  background: var(--accent-lemon);
+}
+
+.chip--strawberry {
+  background: var(--accent-strawberry);
+}
+
+.chip--blueberry {
+  background: var(--accent-blueberry);
+}
+
+.chip--grape {
+  background: var(--accent-grape);
+}
+
+.section--highlight .chip {
+  color: var(--colour-base);
+}
+
+.callout {
+  display: grid;
+  gap: 2rem;
+  align-items: start;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+}
+
+.callout__content ul {
+  padding-left: 1.25rem;
+}
+
+.callout__aside {
+  background: var(--colour-surface-alt);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  border: 1px solid var(--colour-border);
+  display: grid;
+  gap: 0.65rem;
+}
+
+.site-footer {
+  background: #08090d;
+  padding: 3rem 0 1.5rem;
+  border-top: 1px solid var(--colour-border);
+}
+
+.footer__inner {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+}
+
+.footer__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.footer__note {
+  text-align: center;
+  margin-top: 2rem;
+  color: var(--colour-muted);
+  font-size: 0.875rem;
+}
+
+.contact-grid {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  margin-top: 2rem;
+}
+
+.contact-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.contact-form input,
+.contact-form textarea {
+  width: 100%;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--colour-border);
+  background: var(--colour-surface-alt);
+  color: var(--colour-text);
+}
+
+.contact-form input:focus,
+.contact-form textarea:focus {
+  outline: 3px solid var(--accent-strawberry);
+  outline-offset: 3px;
+}
+
+button:focus-visible,
+a:focus-visible {
+  outline: 3px solid var(--accent-lemon);
+  outline-offset: 3px;
+}
+
+@media (max-width: 56rem) {
+  .nav-toggle {
+    display: inline-flex;
+  }
+
+  .nav {
+    position: absolute;
+    top: 100%;
+    right: 1.25rem;
+    background: var(--colour-surface);
+    border: 1px solid var(--colour-border);
+    border-radius: 1rem;
+    box-shadow: var(--shadow-soft);
+    max-height: 0;
+    overflow: hidden;
+  }
+
+  [data-nav-open="true"] .nav {
+    max-height: 15rem;
+  }
+
+  .nav__list {
+    flex-direction: column;
+    padding: 1rem;
+    gap: 1rem;
+    min-width: 12rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+.btn {
+  isolation: isolate;
+}
+
+.ripple {
+  position: absolute;
+  border-radius: 50%;
+  transform: scale(0);
+  background: rgba(255, 255, 255, 0.5);
+  opacity: 0.7;
+  pointer-events: none;
+  animation: ripple 0.6s ease-out;
+}
+
+@keyframes ripple {
+  to {
+    transform: scale(2.5);
+    opacity: 0;
+  }
+}

--- a/assets/images/placeholders/blueberry.svg
+++ b/assets/images/placeholders/blueberry.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title">
+  <title id="title">Blueberry illustration</title>
+  <defs>
+    <radialGradient id="blueberryGradient" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#a9baff" />
+      <stop offset="100%" stop-color="#4d5dff" />
+    </radialGradient>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="#1a1c29" />
+  <circle cx="68" cy="78" r="36" fill="url(#blueberryGradient)" stroke="#7f8dff" stroke-width="6" />
+  <circle cx="104" cy="96" r="28" fill="url(#blueberryGradient)" stroke="#7f8dff" stroke-width="6" />
+  <path d="M68 70l8 6-8 6-8-6z" fill="#1a1c29" opacity="0.65" />
+  <circle cx="58" cy="70" r="6" fill="#d5dcff" />
+  <circle cx="114" cy="90" r="5" fill="#d5dcff" />
+</svg>

--- a/assets/images/placeholders/grape.svg
+++ b/assets/images/placeholders/grape.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title">
+  <title id="title">Grape illustration</title>
+  <defs>
+    <linearGradient id="grapeGradient" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#d9a9ff" />
+      <stop offset="100%" stop-color="#8b3bff" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="#1a1c29" />
+  <g fill="url(#grapeGradient)" stroke="#b96bff" stroke-width="6">
+    <circle cx="80" cy="52" r="20" />
+    <circle cx="60" cy="76" r="22" />
+    <circle cx="100" cy="76" r="22" />
+    <circle cx="70" cy="104" r="22" />
+    <circle cx="110" cy="104" r="22" />
+  </g>
+  <path d="M80 40c4-10 10-18 18-22" fill="none" stroke="#78c26d" stroke-width="6" stroke-linecap="round" />
+</svg>

--- a/assets/images/placeholders/lemon.svg
+++ b/assets/images/placeholders/lemon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title">
+  <title id="title">Lemon illustration</title>
+  <defs>
+    <linearGradient id="lemonGradient" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#fff4a3" />
+      <stop offset="100%" stop-color="#ffc531" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="#1a1c29" />
+  <ellipse cx="80" cy="80" rx="58" ry="42" fill="url(#lemonGradient)" stroke="#ffda5c" stroke-width="6" />
+  <path d="M40 80c12-22 34-32 40-32s28 10 40 32c-12 22-34 32-40 32s-28-10-40-32z" fill="none" stroke="#ffe895" stroke-width="5" stroke-linecap="round" />
+</svg>

--- a/assets/images/placeholders/strawberry.svg
+++ b/assets/images/placeholders/strawberry.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title">
+  <title id="title">Strawberry illustration</title>
+  <defs>
+    <linearGradient id="berryGradient" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#ff9eb8" />
+      <stop offset="100%" stop-color="#ff5277" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="#1a1c29" />
+  <path d="M80 32c-12 0-20 8-24 16-6 10-16 14-16 28 0 30 26 52 40 52s40-22 40-52c0-14-10-18-16-28-4-8-12-16-24-16z" fill="url(#berryGradient)" stroke="#ff6f91" stroke-width="6" stroke-linejoin="round" />
+  <path d="M64 28c8-6 16-6 24 0" fill="none" stroke="#7fd46b" stroke-width="6" stroke-linecap="round" />
+  <path d="M80 32c6-8 12-12 20-12" fill="none" stroke="#6abf5a" stroke-width="6" stroke-linecap="round" />
+  <circle cx="66" cy="76" r="4" fill="#ffe0ea" />
+  <circle cx="80" cy="88" r="4" fill="#ffe0ea" />
+  <circle cx="94" cy="72" r="4" fill="#ffe0ea" />
+  <circle cx="74" cy="104" r="4" fill="#ffe0ea" />
+  <circle cx="98" cy="108" r="4" fill="#ffe0ea" />
+</svg>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,75 @@
+(function () {
+  const header = document.querySelector('[data-nav]');
+  const toggle = document.querySelector('[data-nav-toggle]');
+  const nav = document.getElementById('site-nav');
+
+  if (toggle && header && nav) {
+    toggle.addEventListener('click', () => {
+      const open = header.getAttribute('data-nav-open') === 'true';
+      const nextState = !open;
+      header.setAttribute('data-nav-open', String(nextState));
+      toggle.setAttribute('aria-expanded', String(nextState));
+      if (nextState) {
+        nav.querySelector('a')?.focus();
+      }
+    });
+
+    nav.addEventListener('click', (event) => {
+      if (event.target instanceof HTMLAnchorElement) {
+        header.setAttribute('data-nav-open', 'false');
+        toggle.setAttribute('aria-expanded', 'false');
+      }
+    });
+  }
+
+  const skipLink = document.querySelector('.skip-link');
+  if (skipLink) {
+    skipLink.addEventListener('click', (event) => {
+      const targetId = skipLink.getAttribute('href')?.replace('#', '');
+      if (!targetId) return;
+      const target = document.getElementById(targetId);
+      if (!target) return;
+      event.preventDefault();
+      target.setAttribute('tabindex', '-1');
+      target.focus({ preventScroll: true });
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      target.addEventListener(
+        'blur',
+        () => {
+          target.removeAttribute('tabindex');
+        },
+        { once: true }
+      );
+    });
+  }
+
+  const rippleButtons = document.querySelectorAll('[data-ripple]');
+  rippleButtons.forEach((button) => {
+    button.addEventListener('click', (event) => {
+      const target = event.currentTarget;
+      if (!(target instanceof HTMLElement)) return;
+
+      const ripple = document.createElement('span');
+      ripple.className = 'ripple';
+
+      const rect = target.getBoundingClientRect();
+      const size = Math.max(rect.width, rect.height);
+      const x = event instanceof MouseEvent ? event.clientX - rect.left - size / 2 : rect.width / 2;
+      const y = event instanceof MouseEvent ? event.clientY - rect.top - size / 2 : rect.height / 2;
+
+      ripple.style.width = ripple.style.height = `${size}px`;
+      ripple.style.left = `${x}px`;
+      ripple.style.top = `${y}px`;
+
+      target.appendChild(ripple);
+
+      ripple.addEventListener(
+        'animationend',
+        () => {
+          ripple.remove();
+        },
+        { once: true }
+      );
+    });
+  });
+})();

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <title>Eciggy UK favicon</title>
+  <circle cx="32" cy="32" r="30" fill="currentColor" opacity="0.14" />
+  <path d="M22 42c6 4 14 4 20 0" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" />
+  <path d="M20 26c4-6 8-8 12-8s8 2 12 8" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" />
+  <circle cx="24" cy="32" r="4" fill="currentColor" />
+  <circle cx="40" cy="32" r="4" fill="currentColor" />
+</svg>

--- a/humans.txt
+++ b/humans.txt
@@ -1,0 +1,8 @@
+/* TEAM */
+Designer: Placeholder Name
+Developer: Placeholder Name
+Contact: hello@eciggyuk.example
+
+/* SITE */
+Last update: 2024
+Standards: HTML5, CSS3, WCAG AA

--- a/index.html
+++ b/index.html
@@ -1,298 +1,145 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-GB">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Eciggy UK | Vape Shop & E-Liquid Specialists</title>
-  <link rel="stylesheet" href="assets/css/eciggy-theme.css" />
-  <link rel="stylesheet" href="assets/css/main.css" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Eciggy UK | Fruity E-Liquid Showcase</title>
+  <meta name="description" content="Eciggy UK showcases fruity e-liquids and vape essentials with quick contact details for retail enquiries.">
+  <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
 </head>
-<body class="theme--blackcurrant">
-  <div class="age-gate" id="ageGate" role="dialog" aria-modal="true" aria-hidden="true">
-    <div class="age-gate__dialog">
-      <div class="age-gate__badge" aria-hidden="true">18+</div>
-      <h1 class="age-gate__title">Adults only</h1>
-      <p class="age-gate__text">
-        Eciggy UK sells vaping products intended strictly for adults. Please confirm that you are 18 years of age or older to enter.
-      </p>
-      <div class="age-gate__actions">
-        <button type="button" class="age-gate__confirm" id="ageGateConfirm">I am 18 or older</button>
-        <button type="button" class="age-gate__exit" id="ageGateExit">Leave site</button>
-      </div>
-    </div>
-  </div>
-  <div class="top-bar">
-    <span class="top-bar__item">Free UK delivery on orders over £30</span>
-    <span class="top-bar__item">0330 043 9980</span>
-    <span class="top-bar__item">Same-day dispatch before 4pm</span>
-  </div>
-  <header class="nav">
-    <div class="nav__inner">
-      <a href="#" class="brand" aria-label="Eciggy UK home">
-        <span class="brand__mark">EC</span>
-        <span class="brand__name">Eciggy UK</span>
+<body>
+  <a class="skip-link" href="#main">Skip to main content</a>
+  <header class="site-header" data-nav data-nav-open="false">
+    <div class="container header-inner">
+      <a class="brand" href="index.html">
+        <span class="brand__mark" aria-hidden="true">🍇</span>
+        <span class="brand__text">Eciggy UK</span>
       </a>
-      <button class="btn btn--ghost nav__toggle" type="button" data-nav-toggle aria-label="Toggle navigation">
-        <span class="hidden-visually">Toggle navigation</span>
-        <span aria-hidden="true">Menu</span>
+      <button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle__bar" aria-hidden="true"></span>
+        <span class="nav-toggle__bar" aria-hidden="true"></span>
+        <span class="nav-toggle__bar" aria-hidden="true"></span>
+        <span class="visually-hidden">Toggle navigation</span>
       </button>
-      <ul class="menu" role="list">
-        <li class="menu__item"><a class="menu__link is-lemon" href="#disposables">Disposable Vapes</a></li>
-        <li class="menu__item"><a class="menu__link is-straw" href="#kits">Starter Kits</a></li>
-        <li class="menu__item"><a class="menu__link is-berry" href="#eliquids">E-Liquids</a></li>
-        <li class="menu__item"><a class="menu__link is-grape" href="#coils">Coils & Pods</a></li>
-        <li class="menu__item"><a class="menu__link is-currant" href="#support">Support</a></li>
-      </ul>
-      <a class="btn btn--sticker nav__cta" href="#shop">Shop All Vapes</a>
+      <nav class="nav" id="site-nav" aria-label="Primary">
+        <ul class="nav__list">
+          <li><a href="#flavours">Flavours</a></li>
+          <li><a href="#about">About</a></li>
+          <li><a href="pages/contact.html">Contact</a></li>
+        </ul>
+      </nav>
     </div>
   </header>
-  <main>
-    <section class="section hero" id="shop">
-      <div class="hero__content">
-        <h1>Your UK Vape Destination for Flavor, Value &amp; Expert Support</h1>
-        <p>
-          Eciggy UK helps you stay smoke-free with curated vape kits, bold disposable ranges,
-          and premium e-liquids sourced from trusted brands. Free delivery over £30, and real
-          humans ready to help.
-        </p>
-        <div class="hero__stats">
-          <span class="chip">1000+ 5★ Reviews</span>
-          <span class="chip">2500+ Products in Stock</span>
-          <span class="chip">100% Genuine Brands</span>
+
+  <main id="main">
+    <section class="hero" aria-labelledby="hero-title">
+      <div class="container hero__layout">
+        <div class="hero__copy">
+          <h1 id="hero-title">Fruity vape inspiration from Eciggy UK</h1>
+          <p>
+            Discover vibrant shortfills and nic salts with tasting notes inspired by British fruit bowls.
+            Eciggy UK curates premium blends for retailers who demand quality and consistency.
+          </p>
+          <div class="hero__chips" role="list">
+            <span class="chip chip--lemon" role="listitem">Citrus zest</span>
+            <span class="chip chip--strawberry" role="listitem">Berry burst</span>
+            <span class="chip chip--blueberry" role="listitem">Cool crush</span>
+            <span class="chip chip--grape" role="listitem">Velvet grape</span>
+          </div>
         </div>
-      </div>
-      <div class="hero__card glass-panel">
-        <h2 class="hero__card-title">Need a recommendation?</h2>
-        <p class="hero__card-intro">Let's talk.</p>
-        <p class="hero__card-copy">
-          Call us on 0330 043 9980 for tailored advice—from first vape kits to upgrading your
-          setup. We're real vapers who love to help.
-        </p>
-        <div class="hero__actions">
-          <a class="btn" href="tel:03300439980">Call 0330 043 9980</a>
-          <a class="btn btn--outline" href="mailto:hello@eciggyuk.co.uk">Email the team</a>
+        <div class="hero__visual" aria-hidden="true">
+          <div class="hero__fruit hero__fruit--lemon"></div>
+          <div class="hero__fruit hero__fruit--berry"></div>
+          <div class="hero__fruit hero__fruit--grape"></div>
         </div>
       </div>
     </section>
 
-    <section class="section" id="disposables">
-      <h2>Disposable Vape Best Sellers</h2>
-      <p class="section__lead">Shop the hottest disposable vape brands with consistent flavour, long-lasting battery life, and great multi-buy offers.</p>
-      <div class="section__grid">
-        <article class="card">
-          <span class="card__eyebrow">Elf Bar</span>
-          <h3>Elfa Pro Prefilled Pod Kit</h3>
-          <p>Sleek rechargeable device with prefilled pods. Mix &amp; match flavours in seconds.</p>
-        </article>
-        <article class="card">
-          <span class="card__eyebrow">Lost Mary</span>
-          <h3>BM600 Disposable</h3>
-          <p>Iconic flavours and 20mg salt nic for smooth throat hits—perfect for on-the-go vaping.</p>
-        </article>
-        <article class="card">
-          <span class="card__eyebrow">SKE</span>
-          <h3>Crystal Bar 600</h3>
-          <p>Eye-catching design with consistent vapour production from first puff to last.</p>
-        </article>
+    <section class="section" id="flavours" aria-labelledby="flavour-title">
+      <div class="container">
+        <h2 id="flavour-title">Shop the fruity trio</h2>
+        <p class="section__lead">Three showcase blends with tasting notes, ready for your shelves. Buttons are presentation-only to demonstrate cart styling.</p>
+        <div class="product-grid">
+          <article class="product-card">
+            <img src="assets/images/placeholders/lemon.svg" alt="Illustration of a lemon" width="160" height="160">
+            <div class="product-card__body">
+              <span class="product-card__tag chip chip--lemon">Lemon Zing</span>
+              <h3>Sunrise Sherbet</h3>
+              <p>Fresh Sicilian lemons balanced with a sherbet sparkle for a bright all-day vape.</p>
+              <button type="button" class="btn" data-ripple aria-label="Add Sunrise Sherbet to basket">Add to cart</button>
+            </div>
+          </article>
+          <article class="product-card">
+            <img src="assets/images/placeholders/strawberry.svg" alt="Illustration of strawberries" width="160" height="160">
+            <div class="product-card__body">
+              <span class="product-card__tag chip chip--strawberry">Strawberry Silk</span>
+              <h3>Garden Gala</h3>
+              <p>Plump British strawberries with a hint of vanilla cream for a smooth exhale.</p>
+              <button type="button" class="btn" data-ripple aria-label="Add Garden Gala to basket">Add to cart</button>
+            </div>
+          </article>
+          <article class="product-card">
+            <img src="assets/images/placeholders/blueberry.svg" alt="Illustration of blueberries" width="160" height="160">
+            <div class="product-card__body">
+              <span class="product-card__tag chip chip--blueberry">Blueberry Chill</span>
+              <h3>Midnight Orchard</h3>
+              <p>Juicy blueberries layered with a cool mint finish to keep the flavour crisp.</p>
+              <button type="button" class="btn" data-ripple aria-label="Add Midnight Orchard to basket">Add to cart</button>
+            </div>
+          </article>
+        </div>
       </div>
     </section>
 
-    <section class="section" id="kits">
-      <h2>Starter &amp; Advanced Vape Kits</h2>
-      <p class="section__lead">Whether you're transitioning from smoking or levelling up, our curated kits deliver everything you need inside the box.</p>
-      <div class="section__grid">
-        <article class="card">
-          <span class="card__eyebrow">New to vaping</span>
-          <h3>Simple Pod Kits</h3>
-          <p>Compact, leak-resistant devices with auto-draw technology. Just add your favourite nic salts.</p>
-        </article>
-        <article class="card">
-          <span class="card__eyebrow">Intermediate</span>
-          <h3>Adjustable Vape Mods</h3>
-          <p>Dial in airflow and wattage for the perfect MTL or RDL experience, with long-lasting batteries.</p>
-        </article>
-        <article class="card">
-          <span class="card__eyebrow">Enthusiast</span>
-          <h3>Sub-Ohm Powerhouses</h3>
-          <p>Cloud-chasing kits with mesh coils, colour displays, and advanced safety protections.</p>
-        </article>
-      </div>
-    </section>
-
-    <section class="section" id="eliquids">
-      <h2>E-Liquids for Every Palate</h2>
-      <p class="section__lead">From 10ml nic salts to 50ml shortfills ready for 3mg or 6mg mixes, explore rich dessert blends, clean menthols, and fruity favourites.</p>
-      <div class="section__grid">
-        <article class="card">
-          <span class="card__eyebrow">Nic Salts</span>
-          <h3>Smooth nicotine hit</h3>
-          <p>Perfect for pod systems with quick absorption and refined throat hit.</p>
-        </article>
-        <article class="card">
-          <span class="card__eyebrow">50/50</span>
-          <h3>Balanced blends</h3>
-          <p>Ideal for starter kits—equal parts flavour and vapour production.</p>
-        </article>
-        <article class="card">
-          <span class="card__eyebrow">Shortfills</span>
-          <h3>Big bottles, bold taste</h3>
-          <p>Add nic shots for tailored strengths and enjoy layered flavour profiles.</p>
-        </article>
-      </div>
-    </section>
-
-    <section class="section section--feature" id="shortfills">
-      <h2>Eciggy Signature Shortfill Range</h2>
-      <p class="section__lead">Pair our new artwork collection with detailed product guides for every flavour in the Eciggy line-up.</p>
-      <div class="flavour-grid">
-        <a class="flavour-card" href="products/blackcurrant.html">
-          <img src="assets/images/blackcurrant.png" alt="Eciggy Blackcurrant Burst shortfill bottle" />
-          <div class="flavour-card__body">
-            <h3>Blackcurrant Burst</h3>
-            <p>Woodland berries chilled with a frosty exhale.</p>
-            <span class="flavour-card__cta">View product</span>
-          </div>
-        </a>
-        <a class="flavour-card" href="products/bubblegum.html">
-          <img src="assets/images/bubblegum.png" alt="Eciggy Bubblegum Blitz shortfill bottle" />
-          <div class="flavour-card__body">
-            <h3>Bubblegum Blitz</h3>
-            <p>Nostalgic candy sweetness with a cool twist.</p>
-            <span class="flavour-card__cta">View product</span>
-          </div>
-        </a>
-        <a class="flavour-card" href="products/cherrycola.html">
-          <img src="assets/images/cherrycola.png" alt="Eciggy Cherry Cola Fizz shortfill bottle" />
-          <div class="flavour-card__body">
-            <h3>Cherry Cola Fizz</h3>
-            <p>Sparkling cola syrup with dark cherry depth.</p>
-            <span class="flavour-card__cta">View product</span>
-          </div>
-        </a>
-        <a class="flavour-card" href="products/fruitilicious.html">
-          <img src="assets/images/fruitilicious.png" alt="Eciggy Fruiti-Licious Punch shortfill bottle" />
-          <div class="flavour-card__body">
-            <h3>Fruiti-Licious Punch</h3>
-            <p>Tropical medley of pineapple, mango and kiwi.</p>
-            <span class="flavour-card__cta">View product</span>
-          </div>
-        </a>
-        <a class="flavour-card" href="products/jackblack.html">
-          <img src="assets/images/jackblack.png" alt="Eciggy Jack Black shortfill bottle" />
-          <div class="flavour-card__body">
-            <h3>Jack Black</h3>
-            <p>Aniseed and liquorice with a menthol lift.</p>
-            <span class="flavour-card__cta">View product</span>
-          </div>
-        </a>
-        <a class="flavour-card" href="products/lemonsherbet.html">
-          <img src="assets/images/lemonsherbet.png" alt="Eciggy Lemon Sherbet Pop shortfill bottle" />
-          <div class="flavour-card__body">
-            <h3>Lemon Sherbet Pop</h3>
-            <p>Zingy lemon candy with fizzy sherbet.</p>
-            <span class="flavour-card__cta">View product</span>
-          </div>
-        </a>
-        <a class="flavour-card" href="products/strawgasm.html">
-          <img src="assets/images/strawgasm.png" alt="Eciggy Strawgasm shortfill bottle" />
-          <div class="flavour-card__body">
-            <h3>Strawgasm</h3>
-            <p>Strawberries and cream dessert clouds.</p>
-            <span class="flavour-card__cta">View product</span>
-          </div>
-        </a>
-        <a class="flavour-card" href="products/watermelon.html">
-          <img src="assets/images/watermelon.png" alt="Eciggy Watermelon Wave shortfill bottle" />
-          <div class="flavour-card__body">
-            <h3>Watermelon Wave</h3>
-            <p>Refreshing melon blend with icy finish.</p>
-            <span class="flavour-card__cta">View product</span>
-          </div>
-        </a>
-      </div>
-    </section>
-
-    <section class="section" id="coils">
-      <h2>Coils, Pods &amp; Accessories</h2>
-      <p class="section__lead">Keep your kit running like new with genuine replacement parts shipped directly from our UK warehouse.</p>
-      <div class="section__grid">
-        <article class="card">
-          <span class="card__eyebrow">Mesh coils</span>
-          <h3>Maximum flavour</h3>
-          <p>Enhanced surface area for crisp flavour and dense vapour.</p>
-        </article>
-        <article class="card">
-          <span class="card__eyebrow">Replacement pods</span>
-          <h3>Leak-free vaping</h3>
-          <p>Fresh pods for your favourite kits—fill, click, enjoy.</p>
-        </article>
-        <article class="card">
-          <span class="card__eyebrow">Chargers &amp; cases</span>
-          <h3>Always ready</h3>
-          <p>Keep your gear protected with durable cases and fast USB-C chargers.</p>
-        </article>
-      </div>
-    </section>
-
-    <section class="section" id="support">
-      <h2>Why Shop With Eciggy UK?</h2>
-      <p class="section__lead">We're more than an online basket—we're a team of vape experts dedicated to making your journey smooth, safe, and satisfying.</p>
-      <ul class="benefits">
-        <li>Friendly UK-based support</li>
-        <li>Age-verified purchasing</li>
-        <li>Trusted, TPD-compliant brands</li>
-        <li>Secure payments &amp; Klarna available</li>
-      </ul>
-    </section>
-
-    <section class="section cta-section">
-      <h2>Ready to explore the full Eciggy UK range?</h2>
-      <p>Browse disposables, pod kits, coils, and e-liquids curated by vapers for vapers. Join the smoke-free community today.</p>
-      <div class="cta-links">
-        <a class="btn" href="#disposables">Shop Disposables</a>
-        <a class="btn btn--outline" href="#eliquids">Shop E-Liquids</a>
-        <a class="btn btn--ghost" href="#support">Contact Support</a>
+    <section class="section section--highlight" id="about" aria-labelledby="about-title">
+      <div class="container callout">
+        <div class="callout__content">
+          <h2 id="about-title">About Eciggy UK</h2>
+          <p>
+            Eciggy UK supports independent vape retailers with compliant, lab-tested e-liquids and approachable customer care.
+            Speak with our wholesale team for tasting sessions and stockist pricing.
+          </p>
+          <ul class="callout__list">
+            <li>Responsive UK-based account managers</li>
+            <li>Same-day dispatch across the United Kingdom</li>
+            <li>Marketing-ready imagery and tasting notes</li>
+          </ul>
+        </div>
+        <aside class="callout__aside" aria-label="Contact Eciggy UK">
+          <p><strong>Wholesale enquiries</strong></p>
+          <p>Telephone: <a href="tel:+443300000000">0330 000 0000</a></p>
+          <p>Email: <a href="mailto:hello@eciggyuk.example">hello@eciggyuk.example</a></p>
+          <p><a class="btn btn--outline" href="pages/contact.html">Contact form</a></p>
+        </aside>
       </div>
     </section>
   </main>
 
   <footer class="site-footer">
-    <div class="footer-container">
+    <div class="container footer__inner">
       <div>
-        <h3>Eciggy UK</h3>
-        <p>Registered UK vape retailer supplying high-quality vaping hardware and e-liquids since 2012.</p>
+        <h2 class="footer__title">Eciggy UK</h2>
+        <p>Placeholder retail address, London, United Kingdom.</p>
       </div>
       <div>
-        <h3>Shop</h3>
-        <ul>
-          <li><a href="#disposables">Disposable Vapes</a></li>
-          <li><a href="#kits">Starter Kits</a></li>
-          <li><a href="#eliquids">E-Liquids</a></li>
-          <li><a href="#coils">Coils &amp; Pods</a></li>
+        <h3 class="footer__heading">Browse</h3>
+        <ul class="footer__list">
+          <li><a href="#flavours">Fruity flavours</a></li>
+          <li><a href="#about">Our story</a></li>
+          <li><a href="pages/contact.html">Contact</a></li>
         </ul>
       </div>
       <div>
-        <h3>Customer Care</h3>
-        <ul>
-          <li><a href="mailto:hello@eciggyuk.co.uk">Email Support</a></li>
-          <li><a href="tel:03300439980">0330 043 9980</a></li>
-          <li><a href="#">Delivery &amp; Returns</a></li>
-          <li><a href="#">Age Verification</a></li>
+        <h3 class="footer__heading">Get in touch</h3>
+        <ul class="footer__list">
+          <li><a href="tel:+443300000000">0330 000 0000</a></li>
+          <li><a href="mailto:hello@eciggyuk.example">hello@eciggyuk.example</a></li>
         </ul>
-      </div>
-      <div>
-        <h3>Stay in the loop</h3>
-        <p>Sign up for vape news, flavour drops, and exclusive offers.</p>
-        <form aria-label="Newsletter signup">
-          <label for="email" class="hidden-visually">Email address</label>
-          <input id="email" type="email" name="email" placeholder="Email address" required />
-          <button type="submit" class="btn" data-variant="full-width">Subscribe</button>
-        </form>
       </div>
     </div>
-    <p class="footer-bottom">© <span id="year"></span> Eciggy UK. Vape responsibly. 18+ only.</p>
+    <p class="footer__note">© <span id="year">2024</span> Eciggy UK. Vape responsibly.</p>
   </footer>
-  <script src="assets/js/main.js"></script>
-  <script src="assets/js/eciggy-theme.js" defer></script>
+  <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Contact Eciggy UK</title>
+  <meta name="description" content="Get in touch with Eciggy UK for fruity vape enquiries by phone, email, or form.">
+  <link rel="stylesheet" href="../assets/css/style.css">
+  <link rel="icon" href="../favicon.svg" type="image/svg+xml">
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to main content</a>
+  <header class="site-header" data-nav data-nav-open="false">
+    <div class="container header-inner">
+      <a class="brand" href="../index.html">
+        <span class="brand__mark" aria-hidden="true">🍇</span>
+        <span class="brand__text">Eciggy UK</span>
+      </a>
+      <button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle__bar" aria-hidden="true"></span>
+        <span class="nav-toggle__bar" aria-hidden="true"></span>
+        <span class="nav-toggle__bar" aria-hidden="true"></span>
+        <span class="visually-hidden">Toggle navigation</span>
+      </button>
+      <nav class="nav" id="site-nav" aria-label="Primary">
+        <ul class="nav__list">
+          <li><a href="../index.html#flavours">Flavours</a></li>
+          <li><a href="../index.html#about">About</a></li>
+          <li><a href="contact.html" aria-current="page">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="section" aria-labelledby="contact-title">
+      <div class="container">
+        <h1 id="contact-title">Contact Eciggy UK</h1>
+        <p>We would love to hear from UK retailers interested in fruity e-liquids, flavour sampling, or point-of-sale support.</p>
+        <div class="contact-grid">
+          <div>
+            <h2>Reach us directly</h2>
+            <p><strong>Telephone:</strong> <a href="tel:+443300000000">0330 000 0000</a></p>
+            <p><strong>Email:</strong> <a href="mailto:hello@eciggyuk.example">hello@eciggyuk.example</a></p>
+            <p><strong>Address:</strong> Placeholder retail address, London, United Kingdom.</p>
+          </div>
+          <div>
+            <h2>Send a message</h2>
+            <form action="https://formsubmit.co/your-form-id" method="post" class="contact-form">
+              <input type="hidden" name="_subject" value="New enquiry from Eciggy UK contact page">
+              <label for="name">Name</label>
+              <input id="name" name="name" type="text" autocomplete="name" required>
+              <label for="email">Email</label>
+              <input id="email" name="email" type="email" autocomplete="email" required>
+              <label for="message">Message</label>
+              <textarea id="message" name="message" rows="5" required></textarea>
+              <button type="submit" class="btn" data-ripple>Send enquiry</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <h2 class="footer__title">Eciggy UK</h2>
+        <p>Placeholder retail address, London, United Kingdom.</p>
+      </div>
+      <div>
+        <h3 class="footer__heading">Browse</h3>
+        <ul class="footer__list">
+          <li><a href="../index.html#flavours">Fruity flavours</a></li>
+          <li><a href="../index.html#about">Our story</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="footer__heading">Get in touch</h3>
+        <ul class="footer__list">
+          <li><a href="tel:+443300000000">0330 000 0000</a></li>
+          <li><a href="mailto:hello@eciggyuk.example">hello@eciggyuk.example</a></li>
+        </ul>
+      </div>
+    </div>
+    <p class="footer__note">© <span id="year">2024</span> Eciggy UK. Vape responsibly.</p>
+  </footer>
+  <script src="../assets/js/main.js" defer></script>
+</body>
+</html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://example.com/sitemap.xml

--- a/security.txt
+++ b/security.txt
@@ -1,0 +1,3 @@
+Contact: mailto:security@eciggyuk.example
+Preferred-Languages: en-GB
+Policy: https://example.com/security

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/</loc>
+  </url>
+  <url>
+    <loc>https://example.com/pages/contact.html</loc>
+  </url>
+</urlset>

--- a/structured-data.json
+++ b/structured-data.json
@@ -1,0 +1,34 @@
+{
+  "@context": "https://schema.org",
+  "@type": "LocalBusiness",
+  "name": "Eciggy UK",
+  "url": "https://example.com/",
+  "image": "https://example.com/assets/images/brand.jpg",
+  "telephone": "+44 3300 000000",
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "123 Placeholder Street",
+    "addressLocality": "London",
+    "postalCode": "EC1A 1AA",
+    "addressCountry": "GB"
+  },
+  "openingHoursSpecification": [
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday"
+      ],
+      "opens": "09:00",
+      "closes": "18:00"
+    }
+  ],
+  "sameAs": [
+    "https://www.facebook.com/eciggyuk",
+    "https://www.instagram.com/eciggyuk"
+  ],
+  "priceRange": "££"
+}


### PR DESCRIPTION
## Summary
- replace the landing page with a fruity-themed Eciggy UK brochure including product showcase and contact call-outs
- add a dedicated contact page, shared styles, JavaScript for navigation and accessibility enhancements, and SVG placeholders with a matching favicon
- document deployment and customisation steps plus supporting metadata files for GitHub Pages hosting

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dc32488b288333bff3c658f2f61947