### PR TITLE
Build North Yorkshire Bottled Gas marketing site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Eciggy UK Static Brochure
+# North Yorkshire Bottled Gas Static Site
 
-Fruity-themed static site for Eciggy UK, suitable for GitHub Pages hosting. Includes hero content, product showcase, and a dedicated contact page with FormSubmit integration.
+Marketing-focused static site for North Yorkshire Bottled Gas, a Flogas LPG stockist serving homes and businesses across the county. The site includes a service overview, delivery information, and a dedicated contact form suitable for GitHub Pages hosting.
 
 ## Deploy to GitHub Pages
 1. Push the contents of this repository to the `main` branch on GitHub.
@@ -10,8 +10,9 @@ Fruity-themed static site for Eciggy UK, suitable for GitHub Pages hosting. Incl
 
 ## Customise content
 - **Colours**: Update the CSS custom properties at the top of [`assets/css/style.css`](assets/css/style.css) to adjust background and accent colours.
-- **Telephone link**: Replace the `tel:` value in [`index.html`](index.html) and [`pages/contact.html`](pages/contact.html) with your store's phone number.
-- **FormSubmit action**: Swap `https://formsubmit.co/your-form-id` in [`pages/contact.html`](pages/contact.html) with the FormSubmit endpoint generated for your email address.
+- **Telephone &amp; email links**: Replace the `tel:` and `mailto:` values in [`index.html`](index.html) and [`pages/contact.html`](pages/contact.html) with the latest business contact details.
+- **FormSubmit action**: Swap `https://formsubmit.co/orders@northyorkshirebottledgas.co.uk` in [`pages/contact.html`](pages/contact.html) with the FormSubmit endpoint generated for your email address.
+- **Structured data**: Update [`structured-data.json`](structured-data.json) if your address, phone number, or hours change.
 
 ## Accessibility
 - Semantic HTML structure with skip link and focus outlines.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,15 +1,15 @@
 :root {
   color-scheme: dark light;
-  --colour-base: #0b0c10;
-  --colour-surface: #161821;
-  --colour-surface-alt: #1f2130;
-  --colour-text: #f2f4ff;
-  --colour-muted: rgba(242, 244, 255, 0.72);
-  --colour-border: rgba(242, 244, 255, 0.16);
-  --accent-lemon: #ffd447;
-  --accent-strawberry: #ff6f91;
-  --accent-blueberry: #6d8bff;
-  --accent-grape: #b96bff;
+  --colour-base: #04070f;
+  --colour-surface: #0d1524;
+  --colour-surface-alt: #131f31;
+  --colour-text: #f5f8ff;
+  --colour-muted: rgba(245, 248, 255, 0.72);
+  --colour-border: rgba(245, 248, 255, 0.12);
+  --accent-amber: #ff9f1c;
+  --accent-blue: #1d8fe1;
+  --accent-teal: #2ec4b6;
+  --accent-slate: #8c94b8;
   --font-body: "Poppins", "Segoe UI", sans-serif;
   --max-width: 72rem;
   --transition-speed: 0.3s;
@@ -28,9 +28,9 @@ html {
 body {
   margin: 0;
   font-family: var(--font-body);
-  background: radial-gradient(circle at top left, rgba(255, 214, 71, 0.15), transparent 35%),
-    radial-gradient(circle at top right, rgba(255, 111, 145, 0.15), transparent 40%),
-    radial-gradient(circle at bottom left, rgba(109, 139, 255, 0.12), transparent 45%),
+  background: radial-gradient(circle at top left, rgba(255, 159, 28, 0.18), transparent 40%),
+    radial-gradient(circle at top right, rgba(45, 196, 182, 0.16), transparent 45%),
+    radial-gradient(circle at bottom, rgba(29, 143, 225, 0.18), transparent 50%),
     var(--colour-base);
   color: var(--colour-text);
   line-height: 1.6;
@@ -48,7 +48,7 @@ a {
 
 a:hover,
 a:focus-visible {
-  color: var(--accent-strawberry);
+  color: var(--accent-amber);
 }
 
 .visually-hidden {
@@ -116,7 +116,7 @@ a:focus-visible {
   width: 2.25rem;
   height: 2.25rem;
   border-radius: 50%;
-  background: linear-gradient(135deg, var(--accent-grape), var(--accent-strawberry));
+  background: linear-gradient(135deg, var(--accent-amber), var(--accent-blue));
   font-size: 1.4rem;
 }
 
@@ -208,29 +208,60 @@ a:focus-visible {
 
 .hero__visual {
   display: grid;
-  grid-template-columns: repeat(2, minmax(6rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(6rem, 1fr));
   gap: 1.5rem;
   justify-items: center;
 }
 
-.hero__fruit {
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 2.25rem;
+}
+
+.hero__shape {
   width: 7rem;
-  aspect-ratio: 1 / 1;
-  border-radius: 30% 70% 70% 30% / 40% 30% 70% 60%;
+  height: 10rem;
+  border-radius: 1.75rem 1.75rem 1.25rem 1.25rem;
+  position: relative;
   filter: drop-shadow(var(--shadow-soft));
-  opacity: 0.85;
+  opacity: 0.9;
+  overflow: hidden;
 }
 
-.hero__fruit--lemon {
-  background: linear-gradient(135deg, var(--accent-lemon), #ffb347);
+.hero__shape::before {
+  content: "";
+  position: absolute;
+  top: 0.6rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 65%;
+  height: 0.6rem;
+  border-radius: 0.6rem;
+  background: rgba(8, 13, 23, 0.35);
 }
 
-.hero__fruit--berry {
-  background: linear-gradient(135deg, var(--accent-strawberry), #ff3f74);
+.hero__shape::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1.5rem;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.2), transparent 70%);
 }
 
-.hero__fruit--grape {
-  background: linear-gradient(135deg, var(--accent-grape), #7a3bff);
+.hero__shape--patio {
+  background: linear-gradient(160deg, #ffb24c, var(--accent-amber));
+}
+
+.hero__shape--home {
+  background: linear-gradient(160deg, #3aa1ff, var(--accent-blue));
+}
+
+.hero__shape--forklift {
+  background: linear-gradient(160deg, #36d9c3, var(--accent-teal));
 }
 
 .section {
@@ -292,10 +323,11 @@ a:focus-visible {
   border-radius: 999px;
   border: none;
   cursor: pointer;
-  background: linear-gradient(135deg, var(--accent-strawberry), var(--accent-blueberry));
-  color: #0b0c10;
+  background: linear-gradient(135deg, var(--accent-amber), var(--accent-blue));
+  color: #051017;
   overflow: hidden;
   transition: transform var(--transition-speed) ease;
+  text-decoration: none;
 }
 
 .btn:hover,
@@ -306,13 +338,13 @@ a:focus-visible {
 .btn--outline {
   background: transparent;
   color: var(--colour-text);
-  border: 2px solid var(--accent-blueberry);
+  border: 2px solid var(--accent-teal);
 }
 
 .btn--outline:hover,
 .btn--outline:focus-visible {
   color: var(--colour-base);
-  background: var(--accent-blueberry);
+  background: var(--accent-teal);
 }
 
 .chip {
@@ -326,20 +358,20 @@ a:focus-visible {
   color: var(--colour-base);
 }
 
-.chip--lemon {
-  background: var(--accent-lemon);
+.chip--amber {
+  background: var(--accent-amber);
 }
 
-.chip--strawberry {
-  background: var(--accent-strawberry);
+.chip--blue {
+  background: var(--accent-blue);
 }
 
-.chip--blueberry {
-  background: var(--accent-blueberry);
+.chip--teal {
+  background: var(--accent-teal);
 }
 
-.chip--grape {
-  background: var(--accent-grape);
+.chip--slate {
+  background: var(--accent-slate);
 }
 
 .section--highlight .chip {
@@ -417,14 +449,60 @@ a:focus-visible {
 
 .contact-form input:focus,
 .contact-form textarea:focus {
-  outline: 3px solid var(--accent-strawberry);
+  outline: 3px solid var(--accent-teal);
   outline-offset: 3px;
 }
 
 button:focus-visible,
 a:focus-visible {
-  outline: 3px solid var(--accent-lemon);
+  outline: 3px solid var(--accent-amber);
   outline-offset: 3px;
+}
+
+.area-list {
+  list-style: none;
+  margin: 2rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+}
+
+.area-list li {
+  background: var(--colour-surface-alt);
+  border: 1px solid var(--colour-border);
+  border-radius: 0.75rem;
+  padding: 0.85rem 1rem;
+  font-weight: 600;
+}
+
+.order-steps {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.order-step {
+  background: var(--colour-surface);
+  border: 1px solid var(--colour-border);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.order-step__number {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background: var(--colour-surface-alt);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: var(--accent-amber);
+  font-size: 1.1rem;
 }
 
 @media (max-width: 56rem) {

--- a/assets/images/brand.svg
+++ b/assets/images/brand.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">North Yorkshire Bottled Gas brand mark</title>
+  <desc id="desc">Circular mark featuring a stylised flame above an LPG cylinder silhouette.</desc>
+  <defs>
+    <radialGradient id="glow" cx="50%" cy="35%" r="65%">
+      <stop offset="0%" stop-color="#ffb24c" stop-opacity="0.9" />
+      <stop offset="70%" stop-color="#1d8fe1" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#0d1524" stop-opacity="0.4" />
+    </radialGradient>
+    <linearGradient id="flame" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffb24c" />
+      <stop offset="100%" stop-color="#ff6b3d" />
+    </linearGradient>
+    <linearGradient id="cylinder" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4ab2ff" />
+      <stop offset="100%" stop-color="#1d8fe1" />
+    </linearGradient>
+  </defs>
+  <circle cx="80" cy="80" r="70" fill="#04070f" />
+  <circle cx="80" cy="80" r="68" fill="url(#glow)" />
+  <path d="M80 45c12 12 18 24 12 34-4 6-8 9-12 11-4-2-8-5-12-11-6-10 0-22 12-34z" fill="url(#flame)" />
+  <rect x="52" y="88" width="56" height="44" rx="18" fill="url(#cylinder)" />
+  <rect x="60" y="74" width="40" height="18" rx="9" fill="#2ec4b6" />
+  <rect x="72" y="66" width="16" height="14" rx="5" fill="#1d8fe1" />
+  <rect x="62" y="102" width="36" height="6" rx="3" fill="rgba(255,255,255,0.4)" />
+</svg>

--- a/assets/images/placeholders/cylinder-commercial.svg
+++ b/assets/images/placeholders/cylinder-commercial.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 200" role="img" aria-labelledby="title desc">
+  <title id="title">Teal commercial LPG cylinder illustration</title>
+  <desc id="desc">Stylised illustration of a teal LPG cylinder suited to commercial applications.</desc>
+  <defs>
+    <linearGradient id="commercial-body" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#5ff0d3" />
+      <stop offset="100%" stop-color="#1fa389" />
+    </linearGradient>
+    <linearGradient id="commercial-shadow" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="rgba(0,0,0,0.16)" />
+      <stop offset="100%" stop-color="rgba(0,0,0,0)" />
+    </linearGradient>
+  </defs>
+  <rect x="32" y="36" width="96" height="144" rx="30" fill="url(#commercial-body)" />
+  <rect x="52" y="16" width="56" height="28" rx="13" fill="#2ec4b6" />
+  <rect x="68" y="4" width="24" height="22" rx="6" fill="#20947f" />
+  <rect x="44" y="62" width="72" height="7" rx="3.5" fill="rgba(255,255,255,0.35)" />
+  <path d="M38 152h84v11c0 10-13 18-42 18s-42-8-42-18z" fill="url(#commercial-shadow)" />
+</svg>

--- a/assets/images/placeholders/cylinder-home.svg
+++ b/assets/images/placeholders/cylinder-home.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 200" role="img" aria-labelledby="title desc">
+  <title id="title">Blue domestic LPG cylinder illustration</title>
+  <desc id="desc">Stylised illustration of a tall LPG cylinder with a blue gradient.</desc>
+  <defs>
+    <linearGradient id="home-body" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4ab2ff" />
+      <stop offset="100%" stop-color="#1d8fe1" />
+    </linearGradient>
+    <linearGradient id="home-shadow" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="rgba(0,0,0,0.18)" />
+      <stop offset="100%" stop-color="rgba(0,0,0,0)" />
+    </linearGradient>
+  </defs>
+  <rect x="30" y="30" width="100" height="150" rx="30" fill="url(#home-body)" />
+  <rect x="50" y="12" width="60" height="30" rx="14" fill="#33a0f4" />
+  <rect x="68" y="2" width="24" height="22" rx="6" fill="#1d7fd1" />
+  <rect x="42" y="54" width="76" height="8" rx="4" fill="rgba(255,255,255,0.35)" />
+  <path d="M35 160h90v12c0 11-14 20-45 20s-45-9-45-20z" fill="url(#home-shadow)" />
+</svg>

--- a/assets/images/placeholders/cylinder-leisure.svg
+++ b/assets/images/placeholders/cylinder-leisure.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 200" role="img" aria-labelledby="title desc">
+  <title id="title">Orange patio gas cylinder illustration</title>
+  <desc id="desc">Stylised illustration of an LPG cylinder with an orange gradient body and valve.</desc>
+  <defs>
+    <linearGradient id="body" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffb24c" />
+      <stop offset="100%" stop-color="#ff851c" />
+    </linearGradient>
+    <linearGradient id="shadow" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="rgba(0,0,0,0.15)" />
+      <stop offset="100%" stop-color="rgba(0,0,0,0)" />
+    </linearGradient>
+  </defs>
+  <rect x="35" y="40" width="90" height="140" rx="28" fill="url(#body)" />
+  <rect x="50" y="20" width="60" height="30" rx="14" fill="#ff9f1c" />
+  <rect x="70" y="10" width="20" height="20" rx="6" fill="#e96e0d" />
+  <rect x="45" y="60" width="80" height="6" rx="3" fill="rgba(255,255,255,0.35)" />
+  <path d="M40 150h80v10c0 10-12 18-40 18s-40-8-40-18z" fill="url(#shadow)" />
+</svg>

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,8 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <title>Eciggy UK favicon</title>
-  <circle cx="32" cy="32" r="30" fill="currentColor" opacity="0.14" />
-  <path d="M22 42c6 4 14 4 20 0" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" />
-  <path d="M20 26c4-6 8-8 12-8s8 2 12 8" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" />
-  <circle cx="24" cy="32" r="4" fill="currentColor" />
-  <circle cx="40" cy="32" r="4" fill="currentColor" />
+  <title>North Yorkshire Bottled Gas favicon</title>
+  <defs>
+    <linearGradient id="favicon-flame" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffb24c" />
+      <stop offset="100%" stop-color="#ff6b3d" />
+    </linearGradient>
+    <linearGradient id="favicon-cylinder" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4ab2ff" />
+      <stop offset="100%" stop-color="#1d8fe1" />
+    </linearGradient>
+  </defs>
+  <circle cx="32" cy="32" r="30" fill="#04070f" />
+  <path d="M32 14c6 6 9 12 6 17-2 3-4 5-6 6-2-1-4-3-6-6-3-5 0-11 6-17z" fill="url(#favicon-flame)" />
+  <rect x="22" y="32" width="20" height="14" rx="6" fill="url(#favicon-cylinder)" />
+  <rect x="25" y="27" width="14" height="6" rx="3" fill="#2ec4b6" />
+  <rect x="28" y="23" width="8" height="6" rx="2" fill="#1d8fe1" />
 </svg>

--- a/humans.txt
+++ b/humans.txt
@@ -1,7 +1,7 @@
 /* TEAM */
-Designer: Placeholder Name
-Developer: Placeholder Name
-Contact: hello@eciggyuk.example
+Owner: John Scott
+Developer: ChatGPT (OpenAI)
+Contact: orders@northyorkshirebottledgas.co.uk
 
 /* SITE */
 Last update: 2024

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Eciggy UK | Fruity E-Liquid Showcase</title>
-  <meta name="description" content="Eciggy UK showcases fruity e-liquids and vape essentials with quick contact details for retail enquiries.">
+  <title>North Yorkshire Bottled Gas | LPG Cylinders & Local Delivery</title>
+  <meta name="description" content="North Yorkshire Bottled Gas is a trusted Flogas stockist supplying LPG cylinders with fast delivery across North Yorkshire for homes, farms, and businesses.">
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
 </head>
@@ -13,8 +13,8 @@
   <header class="site-header" data-nav data-nav-open="false">
     <div class="container header-inner">
       <a class="brand" href="index.html">
-        <span class="brand__mark" aria-hidden="true">🍇</span>
-        <span class="brand__text">Eciggy UK</span>
+        <span class="brand__mark" aria-hidden="true">🔥</span>
+        <span class="brand__text">North Yorkshire Bottled Gas</span>
       </a>
       <button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-controls="site-nav">
         <span class="nav-toggle__bar" aria-hidden="true"></span>
@@ -24,7 +24,8 @@
       </button>
       <nav class="nav" id="site-nav" aria-label="Primary">
         <ul class="nav__list">
-          <li><a href="#flavours">Flavours</a></li>
+          <li><a href="#services">Cylinder range</a></li>
+          <li><a href="#delivery">Delivery & safety</a></li>
           <li><a href="#about">About</a></li>
           <li><a href="pages/contact.html">Contact</a></li>
         </ul>
@@ -36,82 +37,124 @@
     <section class="hero" aria-labelledby="hero-title">
       <div class="container hero__layout">
         <div class="hero__copy">
-          <h1 id="hero-title">Fruity vape inspiration from Eciggy UK</h1>
+          <h1 id="hero-title">LPG cylinders for homes, farms, and businesses</h1>
           <p>
-            Discover vibrant shortfills and nic salts with tasting notes inspired by British fruit bowls.
-            Eciggy UK curates premium blends for retailers who demand quality and consistency.
+            North Yorkshire Bottled Gas is a family-run Flogas stockist. We keep patio, domestic heating,
+            forklift and commercial cylinders ready for quick delivery across the county, backed by qualified drivers
+            and attentive customer care.
           </p>
           <div class="hero__chips" role="list">
-            <span class="chip chip--lemon" role="listitem">Citrus zest</span>
-            <span class="chip chip--strawberry" role="listitem">Berry burst</span>
-            <span class="chip chip--blueberry" role="listitem">Cool crush</span>
-            <span class="chip chip--grape" role="listitem">Velvet grape</span>
+            <span class="chip chip--amber" role="listitem">Flogas approved stockist</span>
+            <span class="chip chip--blue" role="listitem">Same and next-day drops</span>
+            <span class="chip chip--teal" role="listitem">Cylinder exchange service</span>
+            <span class="chip chip--slate" role="listitem">Safety checked equipment</span>
+          </div>
+          <div class="hero__actions">
+            <a class="btn" href="tel:+441423324411">Call 01423 324 411</a>
+            <a class="btn btn--outline" href="pages/contact.html">Request a delivery slot</a>
           </div>
         </div>
         <div class="hero__visual" aria-hidden="true">
-          <div class="hero__fruit hero__fruit--lemon"></div>
-          <div class="hero__fruit hero__fruit--berry"></div>
-          <div class="hero__fruit hero__fruit--grape"></div>
+          <div class="hero__shape hero__shape--patio"></div>
+          <div class="hero__shape hero__shape--home"></div>
+          <div class="hero__shape hero__shape--forklift"></div>
         </div>
       </div>
     </section>
 
-    <section class="section" id="flavours" aria-labelledby="flavour-title">
+    <section class="section" id="services" aria-labelledby="services-title">
       <div class="container">
-        <h2 id="flavour-title">Shop the fruity trio</h2>
-        <p class="section__lead">Three showcase blends with tasting notes, ready for your shelves. Buttons are presentation-only to demonstrate cart styling.</p>
+        <h2 id="services-title">Our most-requested cylinders</h2>
+        <p class="section__lead">From BBQ bottles to forklift truck packs, we hold the LPG you need and swap empties for full cylinders on every visit.</p>
         <div class="product-grid">
           <article class="product-card">
-            <img src="assets/images/placeholders/lemon.svg" alt="Illustration of a lemon" width="160" height="160">
+            <img src="assets/images/placeholders/cylinder-leisure.svg" alt="Illustration of an orange patio gas cylinder" width="160" height="200">
             <div class="product-card__body">
-              <span class="product-card__tag chip chip--lemon">Lemon Zing</span>
-              <h3>Sunrise Sherbet</h3>
-              <p>Fresh Sicilian lemons balanced with a sherbet sparkle for a bright all-day vape.</p>
-              <button type="button" class="btn" data-ripple aria-label="Add Sunrise Sherbet to basket">Add to cart</button>
+              <span class="product-card__tag chip chip--amber">Patio & leisure</span>
+              <h3>Patio, BBQ & camping gas</h3>
+              <p>11kg, 13kg and 19kg cylinders for grills, heaters and outdoor events with regulators supplied on request.</p>
+              <button type="button" class="btn" data-ripple aria-label="Enquire about patio and leisure gas">Enquire now</button>
             </div>
           </article>
           <article class="product-card">
-            <img src="assets/images/placeholders/strawberry.svg" alt="Illustration of strawberries" width="160" height="160">
+            <img src="assets/images/placeholders/cylinder-home.svg" alt="Illustration of a blue domestic LPG cylinder" width="160" height="200">
             <div class="product-card__body">
-              <span class="product-card__tag chip chip--strawberry">Strawberry Silk</span>
-              <h3>Garden Gala</h3>
-              <p>Plump British strawberries with a hint of vanilla cream for a smooth exhale.</p>
-              <button type="button" class="btn" data-ripple aria-label="Add Garden Gala to basket">Add to cart</button>
+              <span class="product-card__tag chip chip--blue">Home heating</span>
+              <h3>Domestic heating cylinders</h3>
+              <p>47kg Flogas cylinders with automatic changeover options to keep boilers, cookers and stoves running year-round.</p>
+              <button type="button" class="btn" data-ripple aria-label="Enquire about home heating cylinders">Enquire now</button>
             </div>
           </article>
           <article class="product-card">
-            <img src="assets/images/placeholders/blueberry.svg" alt="Illustration of blueberries" width="160" height="160">
+            <img src="assets/images/placeholders/cylinder-commercial.svg" alt="Illustration of a teal commercial LPG cylinder" width="160" height="200">
             <div class="product-card__body">
-              <span class="product-card__tag chip chip--blueberry">Blueberry Chill</span>
-              <h3>Midnight Orchard</h3>
-              <p>Juicy blueberries layered with a cool mint finish to keep the flavour crisp.</p>
-              <button type="button" class="btn" data-ripple aria-label="Add Midnight Orchard to basket">Add to cart</button>
+              <span class="product-card__tag chip chip--teal">Trade & industry</span>
+              <h3>Forklift & commercial supply</h3>
+              <p>Aluminium and steel FLT packs plus catering and agricultural LPG with account terms for regular drops.</p>
+              <button type="button" class="btn" data-ripple aria-label="Enquire about commercial LPG supply">Enquire now</button>
             </div>
           </article>
         </div>
       </div>
     </section>
 
-    <section class="section section--highlight" id="about" aria-labelledby="about-title">
+    <section class="section section--highlight" id="delivery" aria-labelledby="delivery-title">
       <div class="container callout">
         <div class="callout__content">
-          <h2 id="about-title">About Eciggy UK</h2>
+          <h2 id="delivery-title">Reliable delivery and safety-first support</h2>
           <p>
-            Eciggy UK supports independent vape retailers with compliant, lab-tested e-liquids and approachable customer care.
-            Speak with our wholesale team for tasting sessions and stockist pricing.
+            We operate purpose-built LPG vehicles and deliver on scheduled routes throughout North Yorkshire. Our drivers carry Flogas training,
+            carry out visual safety checks on every drop, and can advise on siting, storage and changeover best practice.
           </p>
           <ul class="callout__list">
-            <li>Responsive UK-based account managers</li>
-            <li>Same-day dispatch across the United Kingdom</li>
-            <li>Marketing-ready imagery and tasting notes</li>
+            <li>Route coverage across Boroughbridge, Easingwold, Ripon, Thirsk, Harrogate and the surrounding villages</li>
+            <li>Emergency call-outs for business-critical LPG users</li>
+            <li>Compliance paperwork and cylinder tracking for your records</li>
+          </ul>
+          <ul class="area-list" aria-label="Key delivery locations">
+            <li>Boroughbridge</li>
+            <li>Thirsk</li>
+            <li>Ripon</li>
+            <li>Easingwold</li>
+            <li>Helmsley</li>
+            <li>Harrogate</li>
           </ul>
         </div>
-        <aside class="callout__aside" aria-label="Contact Eciggy UK">
-          <p><strong>Wholesale enquiries</strong></p>
-          <p>Telephone: <a href="tel:+443300000000">0330 000 0000</a></p>
-          <p>Email: <a href="mailto:hello@eciggyuk.example">hello@eciggyuk.example</a></p>
-          <p><a class="btn btn--outline" href="pages/contact.html">Contact form</a></p>
+        <aside class="callout__aside" aria-label="Contact North Yorkshire Bottled Gas">
+          <p><strong>Order cylinders or request advice</strong></p>
+          <p>Telephone: <a href="tel:+441423324411">01423 324 411</a></p>
+          <p>Email: <a href="mailto:orders@northyorkshirebottledgas.co.uk">orders@northyorkshirebottledgas.co.uk</a></p>
+          <p><a class="btn" href="tel:+441423324411">Call now</a></p>
+          <p><a class="btn btn--outline" href="pages/contact.html">Send us your order</a></p>
+          <p><a href="https://www.flogas.co.uk/stockists/john-scott-ta-north-yorkshire-bottled-gas-3" rel="noopener" target="_blank">View our Flogas stockist listing</a></p>
         </aside>
+      </div>
+    </section>
+
+    <section class="section" id="about" aria-labelledby="about-title">
+      <div class="container">
+        <h2 id="about-title">Family-run service with decades of LPG know-how</h2>
+        <p class="section__lead">
+          John Scott and the North Yorkshire Bottled Gas team have delivered cylinders across the county for more than 20 years.
+          We pride ourselves on personal service, honest advice and dependable supply whatever the season brings.
+        </p>
+        <div class="order-steps" role="list">
+          <div class="order-step" role="listitem">
+            <div class="order-step__number">1</div>
+            <h3>Tell us what you need</h3>
+            <p>Call or complete the form with the cylinder sizes you require and your preferred delivery slot.</p>
+          </div>
+          <div class="order-step" role="listitem">
+            <div class="order-step__number">2</div>
+            <h3>We confirm and schedule</h3>
+            <p>We plan the drop on the next available route, confirm pricing and make sure regulators or changeover kits are ready.</p>
+          </div>
+          <div class="order-step" role="listitem">
+            <div class="order-step__number">3</div>
+            <h3>Delivery and exchange</h3>
+            <p>Our qualified driver swaps empty bottles for full, checks storage safety and leaves paperwork for your records.</p>
+          </div>
+        </div>
       </div>
     </section>
   </main>
@@ -119,26 +162,27 @@
   <footer class="site-footer">
     <div class="container footer__inner">
       <div>
-        <h2 class="footer__title">Eciggy UK</h2>
-        <p>Placeholder retail address, London, United Kingdom.</p>
+        <h2 class="footer__title">North Yorkshire Bottled Gas</h2>
+        <p>Station Yard, Helperby, York, North Yorkshire, YO61 2RY</p>
       </div>
       <div>
         <h3 class="footer__heading">Browse</h3>
         <ul class="footer__list">
-          <li><a href="#flavours">Fruity flavours</a></li>
-          <li><a href="#about">Our story</a></li>
+          <li><a href="#services">Cylinder range</a></li>
+          <li><a href="#delivery">Delivery &amp; safety</a></li>
+          <li><a href="#about">About us</a></li>
           <li><a href="pages/contact.html">Contact</a></li>
         </ul>
       </div>
       <div>
         <h3 class="footer__heading">Get in touch</h3>
         <ul class="footer__list">
-          <li><a href="tel:+443300000000">0330 000 0000</a></li>
-          <li><a href="mailto:hello@eciggyuk.example">hello@eciggyuk.example</a></li>
+          <li><a href="tel:+441423324411">01423 324 411</a></li>
+          <li><a href="mailto:orders@northyorkshirebottledgas.co.uk">orders@northyorkshirebottledgas.co.uk</a></li>
         </ul>
       </div>
     </div>
-    <p class="footer__note">© <span id="year">2024</span> Eciggy UK. Vape responsibly.</p>
+    <p class="footer__note">© <span id="year">2024</span> North Yorkshire Bottled Gas. Gas safe, every time.</p>
   </footer>
   <script src="assets/js/main.js" defer></script>
 </body>

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Contact Eciggy UK</title>
-  <meta name="description" content="Get in touch with Eciggy UK for fruity vape enquiries by phone, email, or form.">
+  <title>Contact North Yorkshire Bottled Gas</title>
+  <meta name="description" content="Contact North Yorkshire Bottled Gas to arrange LPG cylinder deliveries, request safety advice, or open a trade account.">
   <link rel="stylesheet" href="../assets/css/style.css">
   <link rel="icon" href="../favicon.svg" type="image/svg+xml">
 </head>
@@ -13,8 +13,8 @@
   <header class="site-header" data-nav data-nav-open="false">
     <div class="container header-inner">
       <a class="brand" href="../index.html">
-        <span class="brand__mark" aria-hidden="true">🍇</span>
-        <span class="brand__text">Eciggy UK</span>
+        <span class="brand__mark" aria-hidden="true">🔥</span>
+        <span class="brand__text">North Yorkshire Bottled Gas</span>
       </a>
       <button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-controls="site-nav">
         <span class="nav-toggle__bar" aria-hidden="true"></span>
@@ -24,7 +24,8 @@
       </button>
       <nav class="nav" id="site-nav" aria-label="Primary">
         <ul class="nav__list">
-          <li><a href="../index.html#flavours">Flavours</a></li>
+          <li><a href="../index.html#services">Cylinder range</a></li>
+          <li><a href="../index.html#delivery">Delivery &amp; safety</a></li>
           <li><a href="../index.html#about">About</a></li>
           <li><a href="contact.html" aria-current="page">Contact</a></li>
         </ul>
@@ -35,23 +36,29 @@
   <main id="main">
     <section class="section" aria-labelledby="contact-title">
       <div class="container">
-        <h1 id="contact-title">Contact Eciggy UK</h1>
-        <p>We would love to hear from UK retailers interested in fruity e-liquids, flavour sampling, or point-of-sale support.</p>
+        <h1 id="contact-title">Contact North Yorkshire Bottled Gas</h1>
+        <p>
+          Need cylinders in a hurry or planning your next delivery run? Get in touch and the team will confirm stock, timings and safety guidance.
+        </p>
         <div class="contact-grid">
           <div>
             <h2>Reach us directly</h2>
-            <p><strong>Telephone:</strong> <a href="tel:+443300000000">0330 000 0000</a></p>
-            <p><strong>Email:</strong> <a href="mailto:hello@eciggyuk.example">hello@eciggyuk.example</a></p>
-            <p><strong>Address:</strong> Placeholder retail address, London, United Kingdom.</p>
+            <p><strong>Telephone:</strong> <a href="tel:+441423324411">01423 324 411</a></p>
+            <p><strong>Email:</strong> <a href="mailto:orders@northyorkshirebottledgas.co.uk">orders@northyorkshirebottledgas.co.uk</a></p>
+            <p><strong>Address:</strong> Station Yard, Helperby, York, North Yorkshire, YO61 2RY</p>
+            <p><strong>Service area:</strong> Boroughbridge, Easingwold, Ripon, Thirsk, Harrogate and surrounding villages.</p>
+            <p><strong>Flogas listing:</strong> <a href="https://www.flogas.co.uk/stockists/john-scott-ta-north-yorkshire-bottled-gas-3" rel="noopener" target="_blank">View official stockist profile</a></p>
           </div>
           <div>
             <h2>Send a message</h2>
-            <form action="https://formsubmit.co/your-form-id" method="post" class="contact-form">
-              <input type="hidden" name="_subject" value="New enquiry from Eciggy UK contact page">
+            <form action="https://formsubmit.co/orders@northyorkshirebottledgas.co.uk" method="post" class="contact-form">
+              <input type="hidden" name="_subject" value="New enquiry from North Yorkshire Bottled Gas website">
               <label for="name">Name</label>
               <input id="name" name="name" type="text" autocomplete="name" required>
               <label for="email">Email</label>
               <input id="email" name="email" type="email" autocomplete="email" required>
+              <label for="phone">Telephone</label>
+              <input id="phone" name="phone" type="tel" autocomplete="tel">
               <label for="message">Message</label>
               <textarea id="message" name="message" rows="5" required></textarea>
               <button type="submit" class="btn" data-ripple>Send enquiry</button>
@@ -65,26 +72,27 @@
   <footer class="site-footer">
     <div class="container footer__inner">
       <div>
-        <h2 class="footer__title">Eciggy UK</h2>
-        <p>Placeholder retail address, London, United Kingdom.</p>
+        <h2 class="footer__title">North Yorkshire Bottled Gas</h2>
+        <p>Station Yard, Helperby, York, North Yorkshire, YO61 2RY</p>
       </div>
       <div>
         <h3 class="footer__heading">Browse</h3>
         <ul class="footer__list">
-          <li><a href="../index.html#flavours">Fruity flavours</a></li>
-          <li><a href="../index.html#about">Our story</a></li>
+          <li><a href="../index.html#services">Cylinder range</a></li>
+          <li><a href="../index.html#delivery">Delivery &amp; safety</a></li>
+          <li><a href="../index.html#about">About</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </div>
       <div>
         <h3 class="footer__heading">Get in touch</h3>
         <ul class="footer__list">
-          <li><a href="tel:+443300000000">0330 000 0000</a></li>
-          <li><a href="mailto:hello@eciggyuk.example">hello@eciggyuk.example</a></li>
+          <li><a href="tel:+441423324411">01423 324 411</a></li>
+          <li><a href="mailto:orders@northyorkshirebottledgas.co.uk">orders@northyorkshirebottledgas.co.uk</a></li>
         </ul>
       </div>
     </div>
-    <p class="footer__note">© <span id="year">2024</span> Eciggy UK. Vape responsibly.</p>
+    <p class="footer__note">© <span id="year">2024</span> North Yorkshire Bottled Gas. Gas safe, every time.</p>
   </footer>
   <script src="../assets/js/main.js" defer></script>
 </body>

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://example.com/sitemap.xml
+Sitemap: https://northyorkshirebottledgas.co.uk/sitemap.xml

--- a/security.txt
+++ b/security.txt
@@ -1,3 +1,3 @@
-Contact: mailto:security@eciggyuk.example
+Contact: mailto:orders@northyorkshirebottledgas.co.uk
 Preferred-Languages: en-GB
-Policy: https://example.com/security
+Policy: https://northyorkshirebottledgas.co.uk/security

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://example.com/</loc>
+    <loc>https://northyorkshirebottledgas.co.uk/</loc>
   </url>
   <url>
-    <loc>https://example.com/pages/contact.html</loc>
+    <loc>https://northyorkshirebottledgas.co.uk/pages/contact.html</loc>
   </url>
 </urlset>

--- a/structured-data.json
+++ b/structured-data.json
@@ -1,15 +1,16 @@
 {
   "@context": "https://schema.org",
   "@type": "LocalBusiness",
-  "name": "Eciggy UK",
-  "url": "https://example.com/",
-  "image": "https://example.com/assets/images/brand.jpg",
-  "telephone": "+44 3300 000000",
+  "name": "North Yorkshire Bottled Gas",
+  "url": "https://northyorkshirebottledgas.co.uk/",
+  "image": "https://northyorkshirebottledgas.co.uk/assets/images/brand.svg",
+  "telephone": "+44 1423 324411",
   "address": {
     "@type": "PostalAddress",
-    "streetAddress": "123 Placeholder Street",
-    "addressLocality": "London",
-    "postalCode": "EC1A 1AA",
+    "streetAddress": "Station Yard, Helperby",
+    "addressLocality": "York",
+    "addressRegion": "North Yorkshire",
+    "postalCode": "YO61 2RY",
     "addressCountry": "GB"
   },
   "openingHoursSpecification": [
@@ -22,13 +23,18 @@
         "Thursday",
         "Friday"
       ],
-      "opens": "09:00",
+      "opens": "08:00",
       "closes": "18:00"
+    },
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": "Saturday",
+      "opens": "08:00",
+      "closes": "12:00"
     }
   ],
   "sameAs": [
-    "https://www.facebook.com/eciggyuk",
-    "https://www.instagram.com/eciggyuk"
+    "https://www.flogas.co.uk/stockists/john-scott-ta-north-yorkshire-bottled-gas-3"
   ],
   "priceRange": "££"
 }


### PR DESCRIPTION
## Summary
- replace the Eciggy vape content with North Yorkshire Bottled Gas service copy, navigation, and calls to action
- refresh the design system with LPG-inspired colours, hero artwork, and new SVG cylinder illustrations
- update contact details, structured data, sitemap, and site policies for the North Yorkshire Bottled Gas stockist listing

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dc35d75f1c83338472d0bd15e5b145