### PR TITLE
Add dedicated products page with Flogas branding

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -220,6 +220,37 @@ a:focus-visible {
   margin-top: 2.25rem;
 }
 
+.hero__brand {
+  margin-top: 2rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.85rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid var(--colour-border);
+  background: rgba(10, 16, 28, 0.65);
+  box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.22);
+}
+
+.hero__brand-text {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.875rem;
+  line-height: 1.2;
+  color: var(--colour-muted);
+}
+
+.hero__brand-text strong {
+  color: var(--colour-text);
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+}
+
+.hero__brand img {
+  width: 120px;
+  height: auto;
+}
+
 .hero__shape {
   width: 7rem;
   height: 10rem;
@@ -297,6 +328,21 @@ a:focus-visible {
   transition: transform var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
 }
 
+.product-card__media {
+  position: relative;
+  aspect-ratio: 3 / 4;
+  border-radius: 1rem;
+  overflow: hidden;
+  background: rgba(10, 16, 28, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(245, 248, 255, 0.04);
+}
+
+.product-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 .product-card:hover,
 .product-card:focus-within {
   transform: translateY(-0.4rem);
@@ -310,6 +356,41 @@ a:focus-visible {
 
 .product-card__tag {
   justify-self: start;
+}
+
+.product-card__specs {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--colour-muted);
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.95rem;
+}
+
+.brand-partners {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-top: 2.5rem;
+}
+
+.brand-partners__card {
+  padding: 1.25rem 1.75rem;
+  border-radius: 1rem;
+  border: 1px solid var(--colour-border);
+  background: rgba(10, 16, 28, 0.65);
+  box-shadow: 0 1.25rem 2.5rem rgba(0, 0, 0, 0.18);
+  display: grid;
+  gap: 0.65rem;
+  text-align: center;
+}
+
+.brand-partners__card p {
+  margin: 0;
+  color: var(--colour-muted);
+  font-size: 0.95rem;
 }
 
 .btn {

--- a/assets/images/logos/flogas.svg
+++ b/assets/images/logos/flogas.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 64" role="img" aria-labelledby="title desc">
+  <title id="title">Flogas partner logo</title>
+  <desc id="desc">Rounded dual lozenge logo showing the word Flogas across magenta and teal panels.</desc>
+  <defs>
+    <linearGradient id="panel-left" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f72585" />
+      <stop offset="100%" stop-color="#d61f75" />
+    </linearGradient>
+    <linearGradient id="panel-right" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+  </defs>
+  <g fill="none" fill-rule="evenodd">
+    <rect x="4" y="6" width="90" height="52" rx="26" fill="url(#panel-left)" />
+    <rect x="66" y="6" width="90" height="52" rx="26" fill="url(#panel-right)" />
+    <path d="M42.9 21.5c5.8 0 9.6 3.5 9.6 8.9 0 6-4 9.9-9.8 9.9h-8V21.5zm-4.1 5h-3.5v9h3.4c2.9 0 4.8-1.9 4.8-4.5 0-2.7-1.9-4.5-4.7-4.5zm15-5h6.4c5.5 0 8.9 2.7 8.9 7.4 0 4.8-3.6 7.6-9.3 7.6h-6zm6.3 11.6c2.6 0 4.3-1.3 4.3-3.9 0-2.4-1.5-3.7-3.9-3.7h-1.7v7.6zm17.7-11.6h5l7.1 18.8h-5.7l-1-2.9h-6.9l-1 2.9H70zm3.1 11.5h4.2l-2.1-6.1zm15.3-11.5h12.5v4.7h-7.5v2.2h6.4V38h-6.4v2.4h7.7v4.6h-12.7zm25.6 0c6 0 10.1 4 10.1 9.7 0 6-4.1 9.9-10.3 9.9-6 0-10.1-4-10.1-9.8 0-6 4.2-9.8 10.3-9.8zm0 14.8c2.7 0 4.6-2 4.6-4.9 0-3-1.9-5-4.7-5-2.8 0-4.7 2-4.7 5 0 3 1.9 4.9 4.8 4.9z" fill="#fff" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
       <nav class="nav" id="site-nav" aria-label="Primary">
         <ul class="nav__list">
           <li><a href="#services">Cylinder range</a></li>
+          <li><a href="pages/products.html">Products</a></li>
           <li><a href="#delivery">Delivery & safety</a></li>
           <li><a href="#about">About</a></li>
           <li><a href="pages/contact.html">Contact</a></li>
@@ -52,6 +53,13 @@
           <div class="hero__actions">
             <a class="btn" href="tel:+447898366726">Call 0789 8366726</a>
             <a class="btn btn--outline" href="pages/contact.html">Request a delivery slot</a>
+          </div>
+          <div class="hero__brand">
+            <div class="hero__brand-text">
+              <span>Authorised stockist</span>
+              <strong>Flogas LPG</strong>
+            </div>
+            <img src="assets/images/logos/flogas.svg" alt="Flogas logo" width="120" height="48">
           </div>
         </div>
         <div class="hero__visual" aria-hidden="true">
@@ -168,6 +176,7 @@
         <h3 class="footer__heading">Browse</h3>
         <ul class="footer__list">
           <li><a href="#services">Cylinder range</a></li>
+          <li><a href="pages/products.html">Products</a></li>
           <li><a href="#delivery">Delivery &amp; safety</a></li>
           <li><a href="#about">About us</a></li>
           <li><a href="pages/contact.html">Contact</a></li>

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -25,6 +25,7 @@
       <nav class="nav" id="site-nav" aria-label="Primary">
         <ul class="nav__list">
           <li><a href="../index.html#services">Cylinder range</a></li>
+          <li><a href="products.html">Products</a></li>
           <li><a href="../index.html#delivery">Delivery &amp; safety</a></li>
           <li><a href="../index.html#about">About</a></li>
           <li><a href="contact.html" aria-current="page">Contact</a></li>
@@ -95,6 +96,7 @@
         <h3 class="footer__heading">Browse</h3>
         <ul class="footer__list">
           <li><a href="../index.html#services">Cylinder range</a></li>
+          <li><a href="products.html">Products</a></li>
           <li><a href="../index.html#delivery">Delivery &amp; safety</a></li>
           <li><a href="../index.html#about">About</a></li>
           <li><a href="contact.html">Contact</a></li>

--- a/pages/products.html
+++ b/pages/products.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Flogas LPG Cylinders in Stock | North Yorkshire Bottled Gas</title>
+  <meta name="description" content="Browse the Flogas LPG cylinders North Yorkshire Bottled Gas keeps ready for fast local delivery, including patio gas, Gaslight bottles and forklift truck packs.">
+  <link rel="stylesheet" href="../assets/css/style.css">
+  <link rel="icon" href="../favicon.svg" type="image/svg+xml">
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to main content</a>
+  <header class="site-header" data-nav data-nav-open="false">
+    <div class="container header-inner">
+      <a class="brand" href="../index.html">
+        <span class="brand__mark" aria-hidden="true">🔥</span>
+        <span class="brand__text">North Yorkshire Bottled Gas</span>
+      </a>
+      <button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-controls="site-nav">
+        <span class="nav-toggle__bar" aria-hidden="true"></span>
+        <span class="nav-toggle__bar" aria-hidden="true"></span>
+        <span class="nav-toggle__bar" aria-hidden="true"></span>
+        <span class="visually-hidden">Toggle navigation</span>
+      </button>
+      <nav class="nav" id="site-nav" aria-label="Primary">
+        <ul class="nav__list">
+          <li><a href="../index.html#services">Cylinder range</a></li>
+          <li><a href="products.html" aria-current="page">Products</a></li>
+          <li><a href="../index.html#delivery">Delivery &amp; safety</a></li>
+          <li><a href="../index.html#about">About</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="section" aria-labelledby="products-title">
+      <div class="container">
+        <h1 id="products-title">Flogas LPG cylinders ready for delivery</h1>
+        <p class="section__lead">
+          We keep the most requested Flogas bottles on hand so you can swap empties for full cylinders without delay.
+          From compact Gaslight bottles to FLT packs and catering propane, each order is checked, loaded and delivered by our qualified team.
+        </p>
+        <div class="brand-partners">
+          <div class="brand-partners__card">
+            <img src="../assets/images/logos/flogas.svg" alt="Flogas logo" width="160" height="64">
+            <p>Official Flogas partner for North Yorkshire households, farms and businesses.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="cylinder-range-heading">
+      <div class="container">
+        <h2 id="cylinder-range-heading">Popular cylinders kept in stock</h2>
+        <div class="product-grid">
+          <article class="product-card">
+            <figure class="product-card__media">
+              <img src="../image/product-5kg-gaslight.jpeg" alt="5kg Flogas Gaslight patio gas cylinder">
+            </figure>
+            <div class="product-card__body">
+              <span class="product-card__tag chip chip--amber">Patio &amp; leisure</span>
+              <h3>5kg Flogas Gaslight</h3>
+              <p>Lightweight composite bottle ideal for BBQs, small patio heaters and touring caravans.</p>
+              <ul class="product-card__specs">
+                <li>Easy-carry handles and visible gas level</li>
+                <li>27mm clip-on valve</li>
+              </ul>
+              <a class="btn btn--outline" href="contact.html">Reserve a bottle</a>
+            </div>
+          </article>
+
+          <article class="product-card">
+            <figure class="product-card__media">
+              <img src="../image/product-10kg-gaslight.jpeg" alt="10kg Flogas Gaslight patio gas cylinder">
+            </figure>
+            <div class="product-card__body">
+              <span class="product-card__tag chip chip--amber">Patio &amp; leisure</span>
+              <h3>10kg Flogas Gaslight</h3>
+              <p>Longer-lasting Gaslight option for family BBQs, outdoor kitchens and events.</p>
+              <ul class="product-card__specs">
+                <li>Composite shell keeps weight low</li>
+                <li>27mm clip-on valve</li>
+              </ul>
+              <a class="btn btn--outline" href="contact.html">Arrange delivery</a>
+            </div>
+          </article>
+
+          <article class="product-card">
+            <figure class="product-card__media">
+              <img src="../image/product-13kg-butane-gas-cylinder-21mm-clip-on-regulator.jpeg" alt="13kg Flogas butane cylinder with 21mm clip-on regulator">
+            </figure>
+            <div class="product-card__body">
+              <span class="product-card__tag chip chip--amber">Home &amp; leisure</span>
+              <h3>13kg butane with 21mm regulator</h3>
+              <p>Reliable blue cylinder for cabinet heaters, portable cookers and winter patio warmth.</p>
+              <ul class="product-card__specs">
+                <li>Supplied with 21mm clip-on regulator if required</li>
+                <li>Ideal for indoor cabinet heaters</li>
+              </ul>
+              <a class="btn btn--outline" href="contact.html">Book an exchange</a>
+            </div>
+          </article>
+
+          <article class="product-card">
+            <figure class="product-card__media">
+              <img src="../image/product-11kg-propane-gas-cylinder-screw-fit.jpeg" alt="11kg Flogas propane cylinder with screw fitting">
+            </figure>
+            <div class="product-card__body">
+              <span class="product-card__tag chip chip--blue">Domestic heating</span>
+              <h3>11kg propane screw fit</h3>
+              <p>Compact propane for cookers, catering kit and seasonal mobile catering units.</p>
+              <ul class="product-card__specs">
+                <li>Screw-on POL connection</li>
+                <li>Suitable for off-grid cooking and heating</li>
+              </ul>
+              <a class="btn btn--outline" href="contact.html">Check availability</a>
+            </div>
+          </article>
+
+          <article class="product-card">
+            <figure class="product-card__media">
+              <img src="../image/product-19kg-propane-gas-cylinder-screw-fit.jpeg" alt="19kg Flogas propane cylinder">
+            </figure>
+            <div class="product-card__body">
+              <span class="product-card__tag chip chip--blue">Home heating</span>
+              <h3>19kg propane screw fit</h3>
+              <p>Mainstay propane cylinder for fixed domestic heating, catering trailers and workshops.</p>
+              <ul class="product-card__specs">
+                <li>POL screw valve</li>
+                <li>Pairs well with automatic changeover kits</li>
+              </ul>
+              <a class="btn btn--outline" href="contact.html">Schedule a drop</a>
+            </div>
+          </article>
+
+          <article class="product-card">
+            <figure class="product-card__media">
+              <img src="../image/product-11kg-flt-propane-gas-cylinder-screw-fit.jpeg" alt="11kg Flogas forklift propane cylinder">
+            </figure>
+            <div class="product-card__body">
+              <span class="product-card__tag chip chip--teal">Forklift</span>
+              <h3>11kg FLT propane</h3>
+              <p>Aluminium forklift bottle for side-mounted LPG FLTs and materials handling fleets.</p>
+              <ul class="product-card__specs">
+                <li>Includes locating peg and screw connector</li>
+                <li>Available in singles or full cage quantities</li>
+              </ul>
+              <a class="btn btn--outline" href="contact.html">Top up the fleet</a>
+            </div>
+          </article>
+
+          <article class="product-card">
+            <figure class="product-card__media">
+              <img src="../image/product-18kg-flt-propane-gas-cylinder-screw-fit.jpeg" alt="18kg Flogas forklift propane cylinder">
+            </figure>
+            <div class="product-card__body">
+              <span class="product-card__tag chip chip--teal">Forklift</span>
+              <h3>18kg FLT propane</h3>
+              <p>High-capacity cylinder for counterbalance trucks working long shifts and multi-shift operations.</p>
+              <ul class="product-card__specs">
+                <li>Upright or horizontal use options</li>
+                <li>Screw connector with excess flow protection</li>
+              </ul>
+              <a class="btn btn--outline" href="contact.html">Book a cage swap</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section--highlight" aria-labelledby="order-support-heading">
+      <div class="container callout">
+        <div class="callout__content">
+          <h2 id="order-support-heading">Need another size or specialist gas?</h2>
+          <p>Let us know what you are running and we will source the right Flogas cylinder or regulator, including catering packs, autogas and bulk LPG options.</p>
+          <ul class="callout__list">
+            <li>Trade accounts with scheduled deliveries</li>
+            <li>Safety checks and changeover installation</li>
+            <li>Cylinder tracking for compliance</li>
+          </ul>
+        </div>
+        <aside class="callout__aside" aria-label="Contact North Yorkshire Bottled Gas">
+          <p><strong>Ready to order?</strong></p>
+          <p>Telephone: <a href="tel:+447898366726">0789 8366726</a></p>
+          <p>Email: <a href="mailto:orders@northyorkshirebottledgas.co.uk">orders@northyorkshirebottledgas.co.uk</a></p>
+          <p><a class="btn" href="tel:+447898366726">Call now</a></p>
+          <p><a class="btn btn--outline" href="contact.html">Send your product list</a></p>
+        </aside>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer__inner">
+      <div>
+        <h2 class="footer__title">North Yorkshire Bottled Gas</h2>
+        <p>Stark Bank Road, Ellingstring, HG4 4PJ</p>
+      </div>
+      <div>
+        <h3 class="footer__heading">Browse</h3>
+        <ul class="footer__list">
+          <li><a href="../index.html#services">Cylinder range</a></li>
+          <li><a href="products.html">Products</a></li>
+          <li><a href="../index.html#delivery">Delivery &amp; safety</a></li>
+          <li><a href="../index.html#about">About</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="footer__heading">Get in touch</h3>
+        <ul class="footer__list">
+          <li><a href="tel:+447898366726">0789 8366726</a></li>
+        </ul>
+      </div>
+    </div>
+    <p class="footer__note">© <span id="year">2024</span> North Yorkshire Bottled Gas. Gas safe, every time.</p>
+  </footer>
+  <script src="../assets/js/main.js" defer></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,4 +6,7 @@
   <url>
     <loc>https://northyorkshirebottledgas.co.uk/pages/contact.html</loc>
   </url>
+  <url>
+    <loc>https://northyorkshirebottledgas.co.uk/pages/products.html</loc>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add a dedicated products page that showcases the in-stock Flogas cylinders with imagery and enquiry links
- integrate the new Flogas partner logo and navigation links across the site for easy access to the range
- extend shared styles and the sitemap to support the new brand highlight and product media

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dc3c4178ec8333b204d0386d08db74