### PR TITLE
Fix Flogas logo path on products page

### DIFF
--- a/pages/products.html
+++ b/pages/products.html
@@ -44,7 +44,7 @@
         </p>
         <div class="brand-partners">
           <div class="brand-partners__card">
-            <img src="image/og_default.png" alt="Flogas logo" width="160" height="64">
+            <img src="../image/og_default.png" alt="Flogas logo" width="160" height="64">
             <p>Official Flogas partner for North Yorkshire households, farms and businesses.</p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- point the products page Flogas logo to the existing og_default image asset

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc48fb43dc8333ab0313dedd268b2b