### PR TITLE
Update coverage messaging for North Yorkshire and Teesside

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,17 +115,19 @@
             carry out visual safety checks on every drop, and can advise on siting, storage and changeover best practice.
           </p>
           <ul class="callout__list">
-            <li>Route coverage across Boroughbridge, Easingwold, Ripon, Thirsk, Harrogate and the surrounding villages</li>
+            <li>Route coverage across all of North Yorkshire and Teesside, from rural villages to Tees Valley towns</li>
             <li>Emergency call-outs for business-critical LPG users</li>
             <li>Compliance paperwork and cylinder tracking for your records</li>
           </ul>
           <ul class="area-list" aria-label="Key delivery locations">
             <li>Boroughbridge</li>
-            <li>Thirsk</li>
-            <li>Ripon</li>
-            <li>Easingwold</li>
-            <li>Helmsley</li>
             <li>Harrogate</li>
+            <li>Middlesbrough</li>
+            <li>Ripon</li>
+            <li>Stockton-on-Tees</li>
+            <li>Thirsk</li>
+            <li>Whitby</li>
+            <li>Yarm</li>
           </ul>
         </div>
         <aside class="callout__aside" aria-label="Contact North Yorkshire Bottled Gas">

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -39,7 +39,7 @@
       <div class="container">
         <h1 id="contact-title">Contact North Yorkshire Bottled Gas</h1>
         <p>
-          Need cylinders in a hurry or planning your next delivery run? Get in touch and the team will confirm stock, timings and safety guidance.
+          Need cylinders in a hurry or planning your next delivery run? We cover every part of North Yorkshire and Teesside, so the team will confirm stock, timings and safety guidance wherever you're based.
         </p>
         <div class="contact-grid">
           <div>

--- a/pages/products.html
+++ b/pages/products.html
@@ -39,7 +39,7 @@
       <div class="container">
         <h1 id="products-title">Flogas LPG cylinders ready for delivery</h1>
         <p class="section__lead">
-          We keep the most requested Flogas bottles on hand so you can swap empties for full cylinders without delay.
+          We keep the most requested Flogas bottles on hand so you can swap empties for full cylinders without delay across North Yorkshire and Teesside.
           From compact Gaslight bottles to FLT packs and catering propane, each order is checked, loaded and delivered by our qualified team.
         </p>
         <div class="brand-partners">


### PR DESCRIPTION
## Summary
- highlight North Yorkshire and Teesside coverage across the home, contact, and products pages
- broaden the sample delivery locations list to include Tees Valley towns

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68dc497ebe88833399f0307a76709e48