### PR TITLE
Add 47kg propane cylinder product card

### DIFF
--- a/pages/products.html
+++ b/pages/products.html
@@ -137,6 +137,22 @@
 
           <article class="product-card">
             <figure class="product-card__media">
+              <img src="../image/product-47kg-propane-gas-cylinder-screw-fit.jpeg" alt="47kg Flogas propane cylinder with screw fitting">
+            </figure>
+            <div class="product-card__body">
+              <span class="product-card__tag chip chip--blue">Commercial heating</span>
+              <h3>47kg propane screw fit</h3>
+              <p>High-capacity cylinder for whole-home heating, catering kitchens and construction site dryers.</p>
+              <ul class="product-card__specs">
+                <li>Connects via standard POL valve</li>
+                <li>Ideal for manifolds and automatic changeovers</li>
+              </ul>
+              <a class="btn btn--outline" href="contact.html">Order a pair</a>
+            </div>
+          </article>
+
+          <article class="product-card">
+            <figure class="product-card__media">
               <img src="../image/product-11kg-flt-propane-gas-cylinder-screw-fit.jpeg" alt="11kg Flogas forklift propane cylinder">
             </figure>
             <div class="product-card__body">


### PR DESCRIPTION
## Summary
- add the 47kg propane screw-fit cylinder to the product grid with key details and contact link

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68dc4b2a359883338fc896a6a7917c40