### PR TITLE
Add service area strip beneath hero

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -193,6 +193,46 @@ a:focus-visible {
   grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 }
 
+.service-area {
+  background: rgba(10, 16, 28, 0.65);
+  border-top: 1px solid var(--colour-border);
+  border-bottom: 1px solid var(--colour-border);
+  padding: 1.75rem 0;
+}
+
+.service-area__inner {
+  display: grid;
+  gap: 1rem;
+  text-align: center;
+}
+
+.service-area__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--colour-muted);
+}
+
+.service-area__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.65rem;
+}
+
+.service-area__list li {
+  border: 1px solid var(--colour-border);
+  border-radius: 999px;
+  padding: 0.45rem 1rem;
+  background: var(--colour-surface);
+  font-weight: 600;
+}
+
 .hero__copy h1 {
   font-size: clamp(2.25rem, 3vw + 1rem, 3.5rem);
   line-height: 1.15;

--- a/index.html
+++ b/index.html
@@ -70,6 +70,24 @@
       </div>
     </section>
 
+    <section class="service-area" aria-label="Service area">
+      <div class="container service-area__inner">
+        <h2 class="service-area__title">Serving North Yorkshire towns including:</h2>
+        <ul class="service-area__list">
+          <li>Harrogate</li>
+          <li>Ripon</li>
+          <li>Boroughbridge</li>
+          <li>Thirsk</li>
+          <li>Middlesbrough</li>
+          <li>Stockton-on-Tees</li>
+          <li>Whitby</li>
+          <li>Yarm</li>
+          <li>Northallerton</li>
+          <li>Richmond</li>
+        </ul>
+      </div>
+    </section>
+
     <section class="section" id="services" aria-labelledby="services-title">
       <div class="container">
         <h2 id="services-title">Our most-requested cylinders</h2>


### PR DESCRIPTION
## Summary
- add a service area strip beneath the hero to highlight delivery towns for SEO and conversions
- style the new strip with pill badges to match the existing design system

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc4ec5c4688333aa1e2f47a976a72e