### PR TITLE
Switch site to a light theme and polish callout card

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,11 +1,11 @@
 :root {
-  color-scheme: dark light;
-  --colour-base: #04070f;
-  --colour-surface: #0d1524;
-  --colour-surface-alt: #131f31;
-  --colour-text: #f5f8ff;
-  --colour-muted: rgba(245, 248, 255, 0.72);
-  --colour-border: rgba(245, 248, 255, 0.12);
+  color-scheme: light;
+  --colour-base: #f5f7fb;
+  --colour-surface: #ffffff;
+  --colour-surface-alt: #eef2fc;
+  --colour-text: #10213d;
+  --colour-muted: rgba(16, 33, 61, 0.66);
+  --colour-border: rgba(16, 33, 61, 0.14);
   --accent-amber: #ff9f1c;
   --accent-blue: #1d8fe1;
   --accent-teal: #2ec4b6;
@@ -13,7 +13,7 @@
   --font-body: "Poppins", "Segoe UI", sans-serif;
   --max-width: 72rem;
   --transition-speed: 0.3s;
-  --shadow-soft: 0 1.25rem 2.5rem rgba(0, 0, 0, 0.16);
+  --shadow-soft: 0 1.5rem 3rem rgba(15, 43, 80, 0.12);
 }
 
 * {
@@ -28,9 +28,9 @@ html {
 body {
   margin: 0;
   font-family: var(--font-body);
-  background: radial-gradient(circle at top left, rgba(255, 159, 28, 0.18), transparent 40%),
-    radial-gradient(circle at top right, rgba(45, 196, 182, 0.16), transparent 45%),
-    radial-gradient(circle at bottom, rgba(29, 143, 225, 0.18), transparent 50%),
+  background: radial-gradient(circle at top left, rgba(255, 159, 28, 0.18), transparent 45%),
+    radial-gradient(circle at top right, rgba(29, 143, 225, 0.12), transparent 55%),
+    radial-gradient(circle at bottom, rgba(46, 196, 182, 0.12), transparent 55%),
     var(--colour-base);
   color: var(--colour-text);
   line-height: 1.6;
@@ -85,12 +85,13 @@ a:focus-visible {
 }
 
 .site-header {
-  background: rgba(15, 16, 24, 0.85);
-  backdrop-filter: blur(12px);
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(18px);
   position: sticky;
   top: 0;
   z-index: 999;
   border-bottom: 1px solid var(--colour-border);
+  box-shadow: 0 0.75rem 2rem rgba(15, 43, 80, 0.08);
 }
 
 .header-inner {
@@ -194,7 +195,7 @@ a:focus-visible {
 }
 
 .service-area {
-  background: rgba(10, 16, 28, 0.65);
+  background: linear-gradient(90deg, rgba(255, 244, 230, 0.55), rgba(235, 244, 255, 0.6));
   border-top: 1px solid var(--colour-border);
   border-bottom: 1px solid var(--colour-border);
   padding: 1.75rem 0;
@@ -268,8 +269,8 @@ a:focus-visible {
   padding: 0.85rem 1.25rem;
   border-radius: 999px;
   border: 1px solid var(--colour-border);
-  background: rgba(10, 16, 28, 0.65);
-  box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.22);
+  background: var(--colour-surface);
+  box-shadow: 0 1.5rem 3rem rgba(15, 43, 80, 0.12);
 }
 
 .hero__brand-text {
@@ -310,7 +311,7 @@ a:focus-visible {
   width: 65%;
   height: 0.6rem;
   border-radius: 0.6rem;
-  background: rgba(8, 13, 23, 0.35);
+  background: rgba(255, 255, 255, 0.65);
 }
 
 .hero__shape::after {
@@ -340,7 +341,7 @@ a:focus-visible {
 }
 
 .section--highlight {
-  background: rgba(21, 22, 31, 0.85);
+  background: linear-gradient(135deg, rgba(255, 243, 229, 0.85), rgba(235, 244, 255, 0.9));
 }
 
 .section__lead {
@@ -373,8 +374,8 @@ a:focus-visible {
   aspect-ratio: 3 / 4;
   border-radius: 1rem;
   overflow: hidden;
-  background: rgba(10, 16, 28, 0.6);
-  box-shadow: inset 0 0 0 1px rgba(245, 248, 255, 0.04);
+  background: linear-gradient(140deg, rgba(255, 244, 230, 0.55), rgba(235, 244, 255, 0.55));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
 }
 
 .product-card__media img {
@@ -386,7 +387,7 @@ a:focus-visible {
 .product-card:hover,
 .product-card:focus-within {
   transform: translateY(-0.4rem);
-  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.26);
+  box-shadow: 0 1.75rem 3.5rem rgba(15, 43, 80, 0.18);
 }
 
 .product-card__body {
@@ -420,8 +421,8 @@ a:focus-visible {
   padding: 1.25rem 1.75rem;
   border-radius: 1rem;
   border: 1px solid var(--colour-border);
-  background: rgba(10, 16, 28, 0.65);
-  box-shadow: 0 1.25rem 2.5rem rgba(0, 0, 0, 0.18);
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(237, 244, 255, 0.95));
+  box-shadow: var(--shadow-soft);
   display: grid;
   gap: 0.65rem;
   text-align: center;
@@ -476,7 +477,7 @@ a:focus-visible {
   border-radius: 999px;
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--colour-base);
+  color: var(--colour-text);
 }
 
 .chip--amber {
@@ -496,7 +497,7 @@ a:focus-visible {
 }
 
 .section--highlight .chip {
-  color: var(--colour-base);
+  color: var(--colour-text);
 }
 
 .callout {
@@ -511,16 +512,92 @@ a:focus-visible {
 }
 
 .callout__aside {
-  background: var(--colour-surface-alt);
-  border-radius: 1.25rem;
-  padding: 1.75rem;
+  position: relative;
+  background: linear-gradient(180deg, var(--colour-surface) 0%, rgba(239, 245, 255, 0.95) 100%);
+  border-radius: 1.5rem;
+  padding: 2rem;
   border: 1px solid var(--colour-border);
   display: grid;
-  gap: 0.65rem;
+  gap: 1rem;
+  box-shadow: 0 1.25rem 2.5rem rgba(15, 43, 80, 0.14);
+  overflow: hidden;
+}
+
+.callout__aside::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 159, 28, 0.12), rgba(46, 196, 182, 0.12));
+  opacity: 0.75;
+  z-index: 0;
+}
+
+.callout__aside > * {
+  position: relative;
+  z-index: 1;
+}
+
+.callout__title {
+  margin: 0;
+  font-size: clamp(1.35rem, 2vw + 0.5rem, 1.6rem);
+  line-height: 1.2;
+  font-weight: 600;
+}
+
+.callout__subtitle {
+  margin: 0;
+  color: var(--colour-muted);
+}
+
+.callout__details {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.callout__details li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: start;
+  padding: 0.85rem;
+  border-radius: 1rem;
+  background: var(--colour-surface);
+  border: 1px solid rgba(16, 33, 61, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.callout__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, rgba(255, 159, 28, 0.2), rgba(46, 196, 182, 0.2));
+  font-size: 1.25rem;
+}
+
+.callout__label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(16, 33, 61, 0.65);
+  margin-bottom: 0.2rem;
+}
+
+.callout__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
 .site-footer {
-  background: #08090d;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(237, 244, 255, 1));
   padding: 3rem 0 1.5rem;
   border-top: 1px solid var(--colour-border);
 }

--- a/index.html
+++ b/index.html
@@ -149,11 +149,28 @@
           </ul>
         </div>
         <aside class="callout__aside" aria-label="Contact North Yorkshire Bottled Gas">
-          <p><strong>Order cylinders or request advice</strong></p>
-          <p>Telephone: <a href="tel:+447898366726">0789 8366726</a></p>
-          <p>Address: Stark Bank Road, Ellingstring, HG4 4PJ</p>
-          <p><a class="btn" href="tel:+447898366726">Call now</a></p>
-          <p><a class="btn btn--outline" href="pages/contact.html">Send us your order</a></p>
+          <h3 class="callout__title">Order cylinders or request advice</h3>
+          <p class="callout__subtitle">Speak to our team for delivery slots, safety guidance and tailored supply plans.</p>
+          <ul class="callout__details">
+            <li>
+              <span class="callout__icon" aria-hidden="true">📞</span>
+              <div>
+                <span class="callout__label">Telephone</span>
+                <a href="tel:+447898366726">0789 8366726</a>
+              </div>
+            </li>
+            <li>
+              <span class="callout__icon" aria-hidden="true">📍</span>
+              <div>
+                <span class="callout__label">Depot</span>
+                <span>Stark Bank Road, Ellingstring, HG4 4PJ</span>
+              </div>
+            </li>
+          </ul>
+          <div class="callout__actions">
+            <a class="btn" href="tel:+447898366726">Call now</a>
+            <a class="btn btn--outline" href="pages/contact.html">Send us your order</a>
+          </div>
         </aside>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- restyle the global palette to use a light, airy theme with softened shadows
- redesign the delivery callout card with structured contact details and icons
- refresh supporting components so buttons, chips, and highlight sections suit the brighter styling

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dc522166788333b2f36565397b5a4d