### PR TITLE
Remove references to John Scott

### DIFF
--- a/humans.txt
+++ b/humans.txt
@@ -1,5 +1,5 @@
 /* TEAM */
-Owner: John Scott
+Owner: North Yorkshire Bottled Gas
 Developer: ChatGPT (OpenAI)
 Contact: orders@northyorkshirebottledgas.co.uk
 

--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@
       <div class="container">
         <h2 id="about-title">Family-run service with decades of LPG know-how</h2>
         <p class="section__lead">
-          John Scott and the North Yorkshire Bottled Gas team have delivered cylinders across the county for more than 20 years.
+          The North Yorkshire Bottled Gas team has delivered cylinders across the county for more than 20 years.
           We pride ourselves on personal service, honest advice and dependable supply whatever the season brings.
         </p>
         <div class="order-steps" role="list">


### PR DESCRIPTION
## Summary
- replace the about section text to refer to the North Yorkshire Bottled Gas team instead of an individual
- update humans.txt ownership information to remove the personal name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcf91a4a208333bf11e9772f089c7f