### PR TITLE
Use solid color for pill buttons

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -445,7 +445,7 @@ a:focus-visible {
   border-radius: 999px;
   border: none;
   cursor: pointer;
-  background: linear-gradient(135deg, var(--accent-amber), var(--accent-blue));
+  background: var(--accent-amber);
   color: #051017;
   overflow: hidden;
   transition: transform var(--transition-speed) ease;


### PR DESCRIPTION
## Summary
- replace the gradient background on pill buttons with a solid accent color for a consistent appearance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcfaca32a08333879d1e1705d7dd31