### PR TITLE
Adjust home heating hero layout and responsiveness

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -196,11 +196,13 @@ a:focus-visible {
 }
 
 #home-heating-hero {
-  padding: 2.5rem 0 1.5rem;
+  margin-block: var(--space-6);
+  padding: var(--space-3) 0;
 }
 
 .home-heating-hero__media {
   position: relative;
+  height: clamp(280px, 48vh, 520px);
   border-radius: 0.875rem;
   overflow: hidden;
   box-shadow: var(--shadow-soft);
@@ -210,16 +212,20 @@ a:focus-visible {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  object-position: 60% 50%;
+  border-radius: 0.875rem;
   display: block;
 }
 
 .home-heating-hero__overlay {
   position: absolute;
-  inset: 0;
-  left: auto;
-  width: 40%;
-  padding: 3rem 2.5rem;
-  background: linear-gradient(135deg, rgba(8, 20, 40, 0.8), rgba(16, 33, 61, 0.72));
+  top: 50%;
+  right: 3%;
+  transform: translateY(-50%);
+  max-width: 38ch;
+  padding: var(--space-4);
+  background: rgba(9, 18, 28, 0.65);
+  border-radius: 0.75rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -760,23 +766,25 @@ a:focus-visible {
   font-size: 1.1rem;
 }
 
-@media (max-width: 50rem) {
+@media (max-width: 900px) {
   #home-heating-hero {
-    padding: 2rem 0 1rem;
+    padding: var(--space-3) 0;
   }
 
   .home-heating-hero__media {
     display: grid;
-    gap: 1.25rem;
+    gap: var(--space-3);
+    height: auto;
   }
 
   .home-heating-hero__overlay {
     position: static;
-    width: 100%;
-    border-radius: 1.25rem;
-    background: linear-gradient(160deg, rgba(8, 20, 40, 0.92), rgba(16, 33, 61, 0.88));
-    padding: 2rem;
-    box-shadow: none;
+    transform: none;
+    max-width: none;
+    background: transparent;
+    margin-top: var(--space-3);
+    padding: 0;
+    color: inherit;
   }
 
   .home-heating-hero__overlay .btn {


### PR DESCRIPTION
## Summary
- tighten the spacing around the home heating hero and update its media sizing
- restyle the overlay panel to align with new layout and typography requirements
- refresh responsive behavior for smaller viewports with a max-width 900px breakpoint

## Testing
- No automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd056de9dc833390d4c21acb2034ec